### PR TITLE
Enable parent project to specify dependency directory

### DIFF
--- a/CMakeLists-rapidjson.txt.in
+++ b/CMakeLists-rapidjson.txt.in
@@ -5,7 +5,7 @@ project(rapidjson-download NONE)
 include(ExternalProject)
 ExternalProject_Add(rapidjson
   DOWNLOAD_COMMAND	git clone https://github.com/miloyip/rapidjson.git .
-  DOWNLOAD_DIR		"${CMAKE_BINARY_DIR}/third_party/rapidjson/src"
+  DOWNLOAD_DIR		"${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/src"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,10 +126,10 @@ if(UNIX)
 	add_subdirectory(cli)
 endif()
 
-add_subdirectory(tests/integration)
+# add_subdirectory(tests/integration)
 
-add_subdirectory(tests/unit)
-
-add_subdirectory(samples/PubSub)
-
-add_subdirectory(samples/ShadowDelta)
+# add_subdirectory(tests/unit)
+# 
+# add_subdirectory(samples/PubSub)
+# 
+# add_subdirectory(samples/ShadowDelta)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ elseif(WIN32)
 	set(CUSTOM_COMPILER_FLAGS "/W4")
 endif()
 
+if(NOT DEPENDENCY_DIR)
+    set(DEPENDENCY_DIR "third_party")
+endif()
+
 #############################
 # Add SDK Target #
 #############################
@@ -43,12 +47,12 @@ set(SDK_TARGET_NAME aws-iot-sdk-cpp)
 add_library(${SDK_TARGET_NAME} "")
 
 # Download and include rapidjson, not optional
-configure_file(CMakeLists-rapidjson.txt.in ${CMAKE_BINARY_DIR}/third_party/rapidjson/download/CMakeLists.txt)
+configure_file(CMakeLists-rapidjson.txt.in ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/download/CMakeLists.txt)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/third_party/rapidjson/download)
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/download)
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/third_party/rapidjson/download)
-target_include_directories(${SDK_TARGET_NAME} PRIVATE ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/download)
+target_include_directories(${SDK_TARGET_NAME} PRIVATE ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/src/include)
 
 # Get Common SDK Sources
 file(GLOB_RECURSE SDK_SOURCES FOLLOW_SYMLINKS ${PROJECT_SOURCE_DIR}/src/*.cpp)
@@ -126,10 +130,10 @@ if(UNIX)
 	add_subdirectory(cli)
 endif()
 
-# add_subdirectory(tests/integration)
+add_subdirectory(tests/integration)
 
-# add_subdirectory(tests/unit)
-# 
-# add_subdirectory(samples/PubSub)
-# 
-# add_subdirectory(samples/ShadowDelta)
+add_subdirectory(tests/unit)
+
+add_subdirectory(samples/PubSub)
+
+add_subdirectory(samples/ShadowDelta)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(aws-iot-sdk-cpp CXX)
 # Section : Disable in-source builds #
 ######################################
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message( FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt and CMakeFiles folder." )
 endif()
 
@@ -51,8 +51,8 @@ execute_process(COMMAND ${CMAKE_COMMAND} --build .
 target_include_directories(${SDK_TARGET_NAME} PRIVATE ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
 
 # Get Common SDK Sources
-file(GLOB_RECURSE SDK_SOURCES FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/src/*.cpp)
-target_include_directories(${SDK_TARGET_NAME} PRIVATE  ${CMAKE_SOURCE_DIR}/include)
+file(GLOB_RECURSE SDK_SOURCES FOLLOW_SYMLINKS ${PROJECT_SOURCE_DIR}/src/*.cpp)
+target_include_directories(${SDK_TARGET_NAME} PRIVATE  ${PROJECT_SOURCE_DIR}/include)
 target_sources(${SDK_TARGET_NAME} PRIVATE ${SDK_SOURCES})
 
 # Configure Threading library
@@ -64,9 +64,9 @@ if(BUILD_DOCS)
 	find_package(Doxygen REQUIRED)
 	file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/docs)
 	set(DOC_BINARY_DIR ${CMAKE_BINARY_DIR}/docs)
-	set(DOC_SOURCE_DIR ${CMAKE_SOURCE_DIR}/.)
+	set(DOC_SOURCE_DIR ${PROJECT_SOURCE_DIR}/.)
 
-	set(doxygen_conf_in ${CMAKE_SOURCE_DIR}/doxygen/doxygen.conf.in)
+	set(doxygen_conf_in ${PROJECT_SOURCE_DIR}/doxygen/doxygen.conf.in)
 	set(doxygen_conf ${CMAKE_BINARY_DIR}/doxygen/doxygen.conf)
 
 	configure_file(${doxygen_conf_in} ${doxygen_conf} @ONLY)
@@ -83,23 +83,23 @@ endif()
 ################################################
 # TODO : Figure out a better way of handling Visual Studio solutions
 if(MSVC)
-	file(GLOB SDK_COMMON_HEADERS "${CMAKE_SOURCE_DIR}/include/*.hpp")
-	file(GLOB SDK_UTIL_COMMON_HEADERS "${CMAKE_SOURCE_DIR}/include/util/*.hpp")
-	file(GLOB SDK_UTIL_LOGGING_HEADERS "${CMAKE_SOURCE_DIR}/include/util/logging/*.hpp")
-	file(GLOB SDK_UTIL_MEMORY_STL_HEADERS "${CMAKE_SOURCE_DIR}/include/util/memory/stl/*.hpp")
-	file(GLOB SDK_UTIL_THREADING_HEADERS "${CMAKE_SOURCE_DIR}/include/util/threading/*.hpp")
-	file(GLOB SDK_MQTT_HEADERS "${CMAKE_SOURCE_DIR}/include/mqtt/*.hpp")
-	file(GLOB SDK_SHADOW_HEADERS "${CMAKE_SOURCE_DIR}/include/shadow/*.hpp")
+	file(GLOB SDK_COMMON_HEADERS "${PROJECT_SOURCE_DIR}/include/*.hpp")
+	file(GLOB SDK_UTIL_COMMON_HEADERS "${PROJECT_SOURCE_DIR}/include/util/*.hpp")
+	file(GLOB SDK_UTIL_LOGGING_HEADERS "${PROJECT_SOURCE_DIR}/include/util/logging/*.hpp")
+	file(GLOB SDK_UTIL_MEMORY_STL_HEADERS "${PROJECT_SOURCE_DIR}/include/util/memory/stl/*.hpp")
+	file(GLOB SDK_UTIL_THREADING_HEADERS "${PROJECT_SOURCE_DIR}/include/util/threading/*.hpp")
+	file(GLOB SDK_MQTT_HEADERS "${PROJECT_SOURCE_DIR}/include/mqtt/*.hpp")
+	file(GLOB SDK_SHADOW_HEADERS "${PROJECT_SOURCE_DIR}/include/shadow/*.hpp")
 
-	file(GLOB SDK_COMMON_SOURCES "${CMAKE_SOURCE_DIR}/src/*.cpp")
-	file(GLOB SDK_UTIL_COMMON_SOURCES "${CMAKE_SOURCE_DIR}/src/util/*.cpp")
-	file(GLOB SDK_UTIL_LOGGING_SOURCES "${CMAKE_SOURCE_DIR}/src/util/logging/*.cpp")
-	file(GLOB SDK_UTIL_THREADING_SOURCES "${CMAKE_SOURCE_DIR}/src/util/threading/*.cpp")
-	file(GLOB SDK_MQTT_SOURCES "${CMAKE_SOURCE_DIR}/src/mqtt/*.cpp")
-	file(GLOB SDK_SHADOW_SOURCES "${CMAKE_SOURCE_DIR}/src/shadow/*.cpp")
+	file(GLOB SDK_COMMON_SOURCES "${PROJECT_SOURCE_DIR}/src/*.cpp")
+	file(GLOB SDK_UTIL_COMMON_SOURCES "${PROJECT_SOURCE_DIR}/src/util/*.cpp")
+	file(GLOB SDK_UTIL_LOGGING_SOURCES "${PROJECT_SOURCE_DIR}/src/util/logging/*.cpp")
+	file(GLOB SDK_UTIL_THREADING_SOURCES "${PROJECT_SOURCE_DIR}/src/util/threading/*.cpp")
+	file(GLOB SDK_MQTT_SOURCES "${PROJECT_SOURCE_DIR}/src/mqtt/*.cpp")
+	file(GLOB SDK_SHADOW_SOURCES "${PROJECT_SOURCE_DIR}/src/shadow/*.cpp")
 
 	# Required to make Header files visible in Visual Studio
-	file(GLOB_RECURSE SDKHeaders FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/include/*.hpp)
+	file(GLOB_RECURSE SDKHeaders FOLLOW_SYMLINKS ${PROJECT_SOURCE_DIR}/include/*.hpp)
 	target_sources(${SDK_TARGET_NAME} PUBLIC ${SDKHeaders})
 
 	source_group("Header Files\\aws-iot" FILES ${SDK_COMMON_HEADERS})

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(${CLI_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../cl
 find_package(Threads REQUIRED)
 
 # Add SDK includes
-target_include_directories(${CLI_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
+target_include_directories(${CLI_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/src/include)
 target_include_directories(${CLI_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../include)
 
 target_link_libraries(${CLI_TARGET_NAME} PUBLIC "Threads::Threads")

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -5,7 +5,7 @@ project(aws-iot-cli CXX)
 # Section : Disable in-source builds #
 ######################################
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message( FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt and CMakeFiles folder." )
 endif()
 
@@ -38,18 +38,18 @@ endif()
 
 set(CLI_TARGET_NAME aws-iot)
 # Add Target
-add_executable(${CLI_TARGET_NAME} "${CMAKE_SOURCE_DIR}/cli/cli.cpp;${CMAKE_SOURCE_DIR}/common/ConfigCommon.cpp")
+add_executable(${CLI_TARGET_NAME} "${PROJECT_SOURCE_DIR}/cli.cpp;${PROJECT_SOURCE_DIR}/../common/ConfigCommon.cpp")
 
 # Add Target specific includes
-target_include_directories(${CLI_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/common)
-target_include_directories(${CLI_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/cli)
+target_include_directories(${CLI_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../common)
+target_include_directories(${CLI_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../cli)
 
 # Configure Threading library
 find_package(Threads REQUIRED)
 
 # Add SDK includes
 target_include_directories(${CLI_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
-target_include_directories(${CLI_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(${CLI_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../include)
 
 target_link_libraries(${CLI_TARGET_NAME} PUBLIC "Threads::Threads")
 target_link_libraries(${CLI_TARGET_NAME} PUBLIC ${SDK_TARGET_NAME})
@@ -57,7 +57,7 @@ target_link_libraries(${CLI_TARGET_NAME} PUBLIC ${SDK_TARGET_NAME})
 # Copy Json config file
 add_custom_command(TARGET ${CLI_TARGET_NAME} PRE_BUILD
 				COMMAND ${CMAKE_COMMAND} -E
-				copy ${CMAKE_SOURCE_DIR}/common/SampleConfig.json $<TARGET_FILE_DIR:${CLI_TARGET_NAME}>/CliConfig.json)
+				copy ${PROJECT_SOURCE_DIR}/../common/SampleConfig.json $<TARGET_FILE_DIR:${CLI_TARGET_NAME}>/CliConfig.json)
 
 target_link_libraries(${CLI_TARGET_NAME} PUBLIC ${THREAD_LIBRARY_LINK_STRING})
 target_link_libraries(${CLI_TARGET_NAME} PUBLIC ${SDK_TARGET_NAME})
@@ -66,10 +66,10 @@ set_property(TARGET ${CLI_TARGET_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${CU
 # Gather list of all .cert files in "/cert"
 add_custom_command(TARGET ${CLI_TARGET_NAME} PRE_BUILD
 				COMMAND ${CMAKE_COMMAND} -E
-				copy_directory ${CMAKE_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${CLI_TARGET_NAME}>/certs)
+				copy_directory ${PROJECT_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${CLI_TARGET_NAME}>/certs)
 
 if(MSVC)
-	set(CLI_HEADERS "${CMAKE_SOURCE_DIR}/cli/cli.hpp")
+	set(CLI_HEADERS "${PROJECT_SOURCE_DIR}/cli.hpp")
 	target_sources(${CLI_TARGET_NAME} PUBLIC ${CLI_HEADERS})
 	source_group("Header Files\\CLI" FILES ${CLI_HEADERS})
 	source_group("Source Files\\CLI" FILES ${CLI_SOURCES})
@@ -80,4 +80,4 @@ endif()
 #########################
 
 set(NETWORK_WRAPPER_DEST_TARGET ${CLI_TARGET_NAME})
-include(${CMAKE_SOURCE_DIR}/network/CMakeLists.txt.in)
+include(${PROJECT_SOURCE_DIR}/../network/CMakeLists.txt.in)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -66,7 +66,7 @@ set_property(TARGET ${CLI_TARGET_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${CU
 # Gather list of all .cert files in "/cert"
 add_custom_command(TARGET ${CLI_TARGET_NAME} PRE_BUILD
 				COMMAND ${CMAKE_COMMAND} -E
-				copy_directory ${PROJECT_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${CLI_TARGET_NAME}>/certs)
+				copy_directory ${PROJECT_SOURCE_DIR}/../certs $<TARGET_FILE_DIR:${CLI_TARGET_NAME}>/certs)
 
 if(MSVC)
 	set(CLI_HEADERS "${PROJECT_SOURCE_DIR}/cli.hpp")

--- a/network/CMakeLists-mbedtls.txt.in
+++ b/network/CMakeLists-mbedtls.txt.in
@@ -6,8 +6,8 @@ include(ExternalProject)
 ExternalProject_Add(mbedtls
 	GIT_REPOSITORY    https://github.com/ARMmbed/mbedtls.git
 	GIT_TAG           mbedtls-2.3.0
-	SOURCE_DIR        "${CMAKE_BINARY_DIR}/third_party/mbedtls/src"
-	BINARY_DIR        "${CMAKE_BINARY_DIR}/third_party/mbedtls/build"
+	SOURCE_DIR        "${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/src"
+	BINARY_DIR        "${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/build"
 	CONFIGURE_COMMAND ""
 	BUILD_COMMAND     ""
 	INSTALL_COMMAND   ""

--- a/network/CMakeLists.txt.in
+++ b/network/CMakeLists.txt.in
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 # Section : Disable in-source builds #
 ######################################
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message( FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt and CMakeFiles folder." )
 endif()
 
@@ -21,7 +21,7 @@ if(${NETWORK_LIBRARY} MATCHES "MbedTLS")
 	if(NOT DEFINED BUILD_MBEDTLS_ONCE)
 		set(BUILD_MBEDTLS_ONCE CACHE INTERNAL "Done")
 		# Download and unpack googletest at configure time
-		configure_file(${CMAKE_SOURCE_DIR}/network/CMakeLists-mbedtls.txt.in
+		configure_file(${PROJECT_SOURCE_DIR}/network/CMakeLists-mbedtls.txt.in
 				${CMAKE_BINARY_DIR}/third_party/mbedtls/download/CMakeLists.txt)
 
 		execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
@@ -42,13 +42,13 @@ if(${NETWORK_LIBRARY} MATCHES "MbedTLS")
 	target_link_libraries(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC mbedcrypto)
 	target_link_libraries(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC mbedx509)
 
-	set(SslLibraryIncludePaths "${CMAKE_BINARY_DIR}/third_party/mbedtls/src/include;${CMAKE_SOURCE_DIR}/network/MbedTLS")
-	file(GLOB_RECURSE SslLibrarySourcePaths FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/MbedTLS/*.*)
+	set(SslLibraryIncludePaths "${CMAKE_BINARY_DIR}/third_party/mbedtls/src/include;${CMAKE_CURRENT_LIST_DIR}/MbedTLS")
+	file(GLOB_RECURSE SslLibrarySourcePaths FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/MbedTLS/*.*)
 	target_include_directories(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibraryIncludePaths})
 	target_sources(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibrarySourcePaths})
 	if(MSVC)
-		file(GLOB_RECURSE SslLibraryHeaders FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/MbedTLS/*.hpp)
-		file(GLOB_RECURSE SslLibrarySources FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/MbedTLS/*.cpp)
+		file(GLOB_RECURSE SslLibraryHeaders FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/MbedTLS/*.hpp)
+		file(GLOB_RECURSE SslLibrarySources FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/MbedTLS/*.cpp)
 		target_sources(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibraryHeaders})
 		source_group("Header Files\\network\\OpenSSL" FILES ${SslLibraryHeaders})
 		source_group("Source Files\\network\\OpenSSL" FILES ${SslLibrarySources})
@@ -77,14 +77,14 @@ else()
 	endif()
 
 	# Default
-	set(SslLibraryIncludePaths "${OPENSSL_INCLUDE_DIR};${CMAKE_SOURCE_DIR}/network/OpenSSL")
+	set(SslLibraryIncludePaths "${OPENSSL_INCLUDE_DIR}\;${CMAKE_CURRENT_LIST_DIR}/OpenSSL")
 
-	file(GLOB_RECURSE SslLibrarySourcePaths FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/OpenSSL/*.*)
+	file(GLOB_RECURSE SslLibrarySourcePaths FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/OpenSSL/*.*)
 	target_include_directories(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibraryIncludePaths})
 	target_sources(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibrarySourcePaths})
 	if(MSVC)
-		file(GLOB_RECURSE SslLibraryHeaders FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/OpenSSL/*.hpp)
-		file(GLOB_RECURSE SslLibrarySources FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/OpenSSL/*.cpp)
+		file(GLOB_RECURSE SslLibraryHeaders FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/OpenSSL/*.hpp)
+		file(GLOB_RECURSE SslLibrarySources FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/OpenSSL/*.cpp)
 		target_sources(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibraryHeaders})
 		source_group("Header Files\\network\\OpenSSL" FILES ${SslLibraryHeaders})
 		source_group("Source Files\\network\\OpenSSL" FILES ${SslLibrarySources})
@@ -92,20 +92,20 @@ else()
 
 	if(${NETWORK_LIBRARY} MATCHES "WebSocket")
 		add_definitions(-DUSE_WEBSOCKETS)
-		target_include_directories(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${CMAKE_SOURCE_DIR}/network/WebSocket)
-		target_include_directories(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${CMAKE_SOURCE_DIR}/network/WebSocket/wslay)
+		target_include_directories(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/WebSocket)
+		target_include_directories(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/WebSocket/wslay)
 
 		set(SslLibraryIncludePaths "${OPENSSL_INCLUDE_DIR};network/WebSocket/;network/WebSocket/wslay/")
-		file(GLOB_RECURSE SslLibrarySourcePaths FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/WebSocket/*.*)
+		file(GLOB_RECURSE SslLibrarySourcePaths FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/WebSocket/*.*)
 		target_include_directories(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibraryIncludePaths})
 		target_sources(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibrarySourcePaths})
 
 		if(MSVC)
-			file(GLOB_RECURSE WebSocket FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/WebSocket/*.cpp)
-			file(GLOB_RECURSE WebSocketLayer FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/WebSocket/wslay/*.cpp)
+			file(GLOB_RECURSE WebSocket FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/WebSocket/*.cpp)
+			file(GLOB_RECURSE WebSocketLayer FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/WebSocket/wslay/*.cpp)
 
-			file(GLOB_RECURSE WebSocketIncludes FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/WebSocket/*.hpp)
-			file(GLOB_RECURSE WebSocketLayerIncludes FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/network/WebSocket/wslay/*.hpp)
+			file(GLOB_RECURSE WebSocketIncludes FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/WebSocket/*.hpp)
+			file(GLOB_RECURSE WebSocketLayerIncludes FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/WebSocket/wslay/*.hpp)
 			source_group("Header Files\\network\\WebSocket" FILES ${WebSocketIncludes})
 			source_group("Header Files\\network\\WebSocket\\Wslay" FILES ${WebSocketLayerIncludes})
 			source_group("Source Files\\network\\WebSocket" FILES ${WebSocket})

--- a/network/CMakeLists.txt.in
+++ b/network/CMakeLists.txt.in
@@ -22,27 +22,27 @@ if(${NETWORK_LIBRARY} MATCHES "MbedTLS")
 		set(BUILD_MBEDTLS_ONCE CACHE INTERNAL "Done")
 		# Download and unpack googletest at configure time
 		configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists-mbedtls.txt.in
-				${CMAKE_BINARY_DIR}/third_party/mbedtls/download/CMakeLists.txt)
+				${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/download/CMakeLists.txt)
 
 		execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-				WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/third_party/mbedtls/download)
+				WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/download)
 
 		execute_process(COMMAND ${CMAKE_COMMAND} --build .
-				WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/third_party/mbedtls/download)
+				WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/download)
 
 		option(ENABLE_TESTING Off)
-		add_subdirectory(${CMAKE_BINARY_DIR}/third_party/mbedtls/src
-				${CMAKE_BINARY_DIR}/third_party/mbedtls/build)
+		add_subdirectory(${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/src
+				${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/build)
 	endif()
 
 	add_custom_command(TARGET ${NETWORK_WRAPPER_DEST_TARGET} PRE_BUILD
-			COMMAND $(MAKE) -C ${CMAKE_BINARY_DIR}/third_party/mbedtls/src)
-	set(MBEDTLS_LIB_DIR "${CMAKE_BINARY_DIR}/third_party/mbedtls/src/library")
+			COMMAND $(MAKE) -C ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/src)
+	set(MBEDTLS_LIB_DIR "${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/src/library")
 	target_link_libraries(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC mbedtls)
 	target_link_libraries(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC mbedcrypto)
 	target_link_libraries(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC mbedx509)
 
-	set(SslLibraryIncludePaths "${CMAKE_BINARY_DIR}/third_party/mbedtls/src/include;${CMAKE_CURRENT_LIST_DIR}/MbedTLS")
+	set(SslLibraryIncludePaths "${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/mbedtls/src/include;${CMAKE_CURRENT_LIST_DIR}/MbedTLS")
 	file(GLOB_RECURSE SslLibrarySourcePaths FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/MbedTLS/*.*)
 	target_include_directories(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibraryIncludePaths})
 	target_sources(${NETWORK_WRAPPER_DEST_TARGET} PUBLIC ${SslLibrarySourcePaths})

--- a/network/CMakeLists.txt.in
+++ b/network/CMakeLists.txt.in
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 # Section : Disable in-source builds #
 ######################################
 
-if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${CMAKE_CURRENT_LIST_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message( FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt and CMakeFiles folder." )
 endif()
 
@@ -21,7 +21,7 @@ if(${NETWORK_LIBRARY} MATCHES "MbedTLS")
 	if(NOT DEFINED BUILD_MBEDTLS_ONCE)
 		set(BUILD_MBEDTLS_ONCE CACHE INTERNAL "Done")
 		# Download and unpack googletest at configure time
-		configure_file(${PROJECT_SOURCE_DIR}/network/CMakeLists-mbedtls.txt.in
+		configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists-mbedtls.txt.in
 				${CMAKE_BINARY_DIR}/third_party/mbedtls/download/CMakeLists.txt)
 
 		execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .

--- a/samples/PubSub/CMakeLists.txt
+++ b/samples/PubSub/CMakeLists.txt
@@ -5,7 +5,7 @@ project(aws-iot-cpp-samples CXX)
 # Section : Disable in-source builds #
 ######################################
 
-if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
+if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message( FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt and CMakeFiles folder." )
 endif()
 
@@ -80,5 +80,3 @@ endif()
 
 set(NETWORK_WRAPPER_DEST_TARGET ${PUB_SUB_SAMPLE_TARGET_NAME})
 include(${PROJECT_SOURCE_DIR}/../../network/CMakeLists.txt.in)
-
-MESSAGE( STATUS "CMAKE_INCLUDE_PATH: " ${CMAKE_INCLUDE_PATH} )

--- a/samples/PubSub/CMakeLists.txt
+++ b/samples/PubSub/CMakeLists.txt
@@ -62,7 +62,7 @@ set_property(TARGET ${PUB_SUB_SAMPLE_TARGET_NAME} APPEND_STRING PROPERTY COMPILE
 # Gather list of all .cert files in "/cert"
 add_custom_command(TARGET ${PUB_SUB_SAMPLE_TARGET_NAME} PRE_BUILD
 		COMMAND ${CMAKE_COMMAND} -E
-		copy_directory ${PROJECT_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${PUB_SUB_SAMPLE_TARGET_NAME}>/certs)
+		copy_directory ${PROJECT_SOURCE_DIR}/../../certs $<TARGET_FILE_DIR:${PUB_SUB_SAMPLE_TARGET_NAME}>/certs)
 
 if(MSVC)
 	target_sources(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.hpp)

--- a/samples/PubSub/CMakeLists.txt
+++ b/samples/PubSub/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE
 find_package(Threads REQUIRED)
 
 # Add SDK includes
-target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
+target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/src/include)
 target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../include)
 
 target_link_libraries(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC "Threads::Threads")

--- a/samples/PubSub/CMakeLists.txt
+++ b/samples/PubSub/CMakeLists.txt
@@ -5,7 +5,7 @@ project(aws-iot-cpp-samples CXX)
 # Section : Disable in-source builds #
 ######################################
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
 	message( FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt and CMakeFiles folder." )
 endif()
 
@@ -37,18 +37,18 @@ endif()
 ################################
 set(PUB_SUB_SAMPLE_TARGET_NAME pub-sub-sample)
 # Add Target
-add_executable(${PUB_SUB_SAMPLE_TARGET_NAME} "${CMAKE_SOURCE_DIR}/samples/PubSub/PubSub.cpp;${CMAKE_SOURCE_DIR}/common/ConfigCommon.cpp")
+add_executable(${PUB_SUB_SAMPLE_TARGET_NAME} "${PROJECT_SOURCE_DIR}/PubSub.cpp;${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.cpp")
 
 # Add Target specific includes
-target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/common)
-target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/samples/PubSub)
+target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../common)
+target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../samples/PubSub)
 
 # Configure Threading library
 find_package(Threads REQUIRED)
 
 # Add SDK includes
 target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
-target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../include)
 
 target_link_libraries(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC "Threads::Threads")
 target_link_libraries(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${SDK_TARGET_NAME})
@@ -56,22 +56,22 @@ target_link_libraries(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${SDK_TARGET_NAME})
 # Copy Json config file
 add_custom_command(TARGET ${PUB_SUB_SAMPLE_TARGET_NAME} POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E
-		copy ${CMAKE_SOURCE_DIR}/common/SampleConfig.json $<TARGET_FILE_DIR:${PUB_SUB_SAMPLE_TARGET_NAME}>/config/SampleConfig.json)
+		copy ${PROJECT_SOURCE_DIR}/../../common/SampleConfig.json $<TARGET_FILE_DIR:${PUB_SUB_SAMPLE_TARGET_NAME}>/config/SampleConfig.json)
 set_property(TARGET ${PUB_SUB_SAMPLE_TARGET_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${CUSTOM_COMPILER_FLAGS})
 
 # Gather list of all .cert files in "/cert"
 add_custom_command(TARGET ${PUB_SUB_SAMPLE_TARGET_NAME} PRE_BUILD
 		COMMAND ${CMAKE_COMMAND} -E
-		copy_directory ${CMAKE_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${PUB_SUB_SAMPLE_TARGET_NAME}>/certs)
+		copy_directory ${PROJECT_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${PUB_SUB_SAMPLE_TARGET_NAME}>/certs)
 
 if(MSVC)
-	target_sources(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/common/ConfigCommon.hpp)
-	source_group("Header Files\\Samples\\PubSub" FILES ${CMAKE_SOURCE_DIR}/common/ConfigCommon.hpp)
-	source_group("Source Files\\Samples\\PubSub" FILES ${CMAKE_SOURCE_DIR}/common/ConfigCommon.cpp)
+	target_sources(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.hpp)
+	source_group("Header Files\\Samples\\PubSub" FILES ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.hpp)
+	source_group("Source Files\\Samples\\PubSub" FILES ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.cpp)
 
-	target_sources(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/samples/PubSub/PubSub.hpp)
-	source_group("Header Files\\Samples\\PubSub" FILES ${CMAKE_SOURCE_DIR}/samples/PubSub/PubSub.hpp)
-	source_group("Source Files\\Samples\\PubSub" FILES ${CMAKE_SOURCE_DIR}/samples/PubSub/PubSub.cpp)
+	target_sources(${PUB_SUB_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../samples/PubSub/PubSub.hpp)
+	source_group("Header Files\\Samples\\PubSub" FILES ${PROJECT_SOURCE_DIR}/../../samples/PubSub/PubSub.hpp)
+	source_group("Source Files\\Samples\\PubSub" FILES ${PROJECT_SOURCE_DIR}/../../samples/PubSub/PubSub.cpp)
 endif()
 
 #########################
@@ -79,4 +79,6 @@ endif()
 #########################
 
 set(NETWORK_WRAPPER_DEST_TARGET ${PUB_SUB_SAMPLE_TARGET_NAME})
-include(${CMAKE_SOURCE_DIR}/network/CMakeLists.txt.in)
+include(${PROJECT_SOURCE_DIR}/../../network/CMakeLists.txt.in)
+
+MESSAGE( STATUS "CMAKE_INCLUDE_PATH: " ${CMAKE_INCLUDE_PATH} )

--- a/samples/ShadowDelta/CMakeLists.txt
+++ b/samples/ShadowDelta/CMakeLists.txt
@@ -62,7 +62,7 @@ set_property(TARGET ${SHADOW_DELTA_SAMPLE_TARGET_NAME} APPEND_STRING PROPERTY CO
 # Gather list of all .cert files in "/cert"
 add_custom_command(TARGET ${SHADOW_DELTA_SAMPLE_TARGET_NAME} PRE_BUILD
 		COMMAND ${CMAKE_COMMAND} -E
-		copy_directory ${PROJECT_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${SHADOW_DELTA_SAMPLE_TARGET_NAME}>/certs)
+		copy_directory ${PROJECT_SOURCE_DIR}/../../certs $<TARGET_FILE_DIR:${SHADOW_DELTA_SAMPLE_TARGET_NAME}>/certs)
 
 if(MSVC)
 	target_sources(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.hpp)

--- a/samples/ShadowDelta/CMakeLists.txt
+++ b/samples/ShadowDelta/CMakeLists.txt
@@ -5,7 +5,7 @@ project(aws-iot-cpp-samples CXX)
 # Section : Disable in-source builds #
 ######################################
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message( FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt and CMakeFiles folder." )
 endif()
 
@@ -37,18 +37,18 @@ endif()
 ################################
 set(SHADOW_DELTA_SAMPLE_TARGET_NAME shadow-delta-sample)
 # Add Target
-add_executable(${SHADOW_DELTA_SAMPLE_TARGET_NAME} "${CMAKE_SOURCE_DIR}/samples/ShadowDelta/ShadowDelta.cpp;${CMAKE_SOURCE_DIR}/common/ConfigCommon.cpp")
+add_executable(${SHADOW_DELTA_SAMPLE_TARGET_NAME} "${PROJECT_SOURCE_DIR}/ShadowDelta.cpp;${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.cpp")
 
 # Add Target specific includes
-target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/common)
-target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/samples/ShadowDelta)
+target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../common)
+target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../samples/ShadowDelta)
 
 # Configure Threading library
 find_package(Threads REQUIRED)
 
 # Add SDK includes
 target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
-target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../include)
 
 target_link_libraries(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC "Threads::Threads")
 target_link_libraries(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${SDK_TARGET_NAME})
@@ -56,22 +56,22 @@ target_link_libraries(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${SDK_TARGET_NAM
 # Copy Json config file
 add_custom_command(TARGET ${SHADOW_DELTA_SAMPLE_TARGET_NAME} POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E
-		copy ${CMAKE_SOURCE_DIR}/common/SampleConfig.json $<TARGET_FILE_DIR:${SHADOW_DELTA_SAMPLE_TARGET_NAME}>/config/SampleConfig.json)
+		copy ${PROJECT_SOURCE_DIR}/../../common/SampleConfig.json $<TARGET_FILE_DIR:${SHADOW_DELTA_SAMPLE_TARGET_NAME}>/config/SampleConfig.json)
 set_property(TARGET ${SHADOW_DELTA_SAMPLE_TARGET_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${CUSTOM_COMPILER_FLAGS})
 
 # Gather list of all .cert files in "/cert"
 add_custom_command(TARGET ${SHADOW_DELTA_SAMPLE_TARGET_NAME} PRE_BUILD
 		COMMAND ${CMAKE_COMMAND} -E
-		copy_directory ${CMAKE_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${SHADOW_DELTA_SAMPLE_TARGET_NAME}>/certs)
+		copy_directory ${PROJECT_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${SHADOW_DELTA_SAMPLE_TARGET_NAME}>/certs)
 
 if(MSVC)
-	target_sources(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/common/ConfigCommon.hpp)
-	source_group("Header Files\\Samples\\ShadowDelta" FILES ${CMAKE_SOURCE_DIR}/common/ConfigCommon.hpp)
-	source_group("Source Files\\Samples\\ShadowDelta" FILES ${CMAKE_SOURCE_DIR}/common/ConfigCommon.cpp)
+	target_sources(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.hpp)
+	source_group("Header Files\\Samples\\ShadowDelta" FILES ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.hpp)
+	source_group("Source Files\\Samples\\ShadowDelta" FILES ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.cpp)
 
-	target_sources(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/samples/ShadowDelta/ShadowDelta.hpp)
-	source_group("Header Files\\Samples\\ShadowDelta" FILES ${CMAKE_SOURCE_DIR}/samples/ShadowDelta/ShadowDelta.hpp)
-	source_group("Source Files\\Samples\\ShadowDelta" FILES ${CMAKE_SOURCE_DIR}/samples/ShadowDelta/ShadowDelta.cpp)
+	target_sources(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../samples/ShadowDelta/ShadowDelta.hpp)
+	source_group("Header Files\\Samples\\ShadowDelta" FILES ${PROJECT_SOURCE_DIR}/../../samples/ShadowDelta/ShadowDelta.hpp)
+	source_group("Source Files\\Samples\\ShadowDelta" FILES ${PROJECT_SOURCE_DIR}/../../samples/ShadowDelta/ShadowDelta.cpp)
 endif()
 
 #########################
@@ -79,4 +79,4 @@ endif()
 #########################
 
 set(NETWORK_WRAPPER_DEST_TARGET ${SHADOW_DELTA_SAMPLE_TARGET_NAME})
-include(${CMAKE_SOURCE_DIR}/network/CMakeLists.txt.in)
+include(${PROJECT_SOURCE_DIR}/../../network/CMakeLists.txt.in)

--- a/samples/ShadowDelta/CMakeLists.txt
+++ b/samples/ShadowDelta/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_S
 find_package(Threads REQUIRED)
 
 # Add SDK includes
-target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
+target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/src/include)
 target_include_directories(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../include)
 
 target_link_libraries(${SHADOW_DELTA_SAMPLE_TARGET_NAME} PUBLIC "Threads::Threads")

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -5,7 +5,7 @@ project(aws-iot-cpp-integration-tests CXX)
 # Section : Disable in-source builds #
 ######################################
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message( FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt and CMakeFiles folder." )
 endif()
 
@@ -37,27 +37,27 @@ endif()
 ####################################
 set(INTEGRATION_TEST_TARGET_NAME aws-iot-integration-tests)
 # Add Target
-add_executable(${INTEGRATION_TEST_TARGET_NAME} "${CMAKE_SOURCE_DIR}/common/ConfigCommon.cpp")
+add_executable(${INTEGRATION_TEST_TARGET_NAME} "${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.cpp")
 
 target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
-target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../include)
 
 # Configure Threading library
 find_package(Threads REQUIRED)
 target_link_libraries(${INTEGRATION_TEST_TARGET_NAME} PUBLIC "Threads::Threads")
 
 # Integration Tests
-file(GLOB_RECURSE INTEGRATION_TEST_SOURCES FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/tests/integration/src/*.cpp)
+file(GLOB_RECURSE INTEGRATION_TEST_SOURCES FOLLOW_SYMLINKS ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
 # Add Target specific includes
-target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/common)
-target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/tests/integration/include)
+target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../common)
+target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_sources(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${INTEGRATION_TEST_SOURCES})
 
 # Copy Json config file
 add_custom_command(TARGET ${INTEGRATION_TEST_TARGET_NAME} POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E
-		copy ${CMAKE_SOURCE_DIR}/common/SampleConfig.json $<TARGET_FILE_DIR:${INTEGRATION_TEST_TARGET_NAME}>/config/IntegrationTestConfig.json)
+		copy ${PROJECT_SOURCE_DIR}/../../common/SampleConfig.json $<TARGET_FILE_DIR:${INTEGRATION_TEST_TARGET_NAME}>/config/IntegrationTestConfig.json)
 
 target_link_libraries(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${THREAD_LIBRARY_LINK_STRING})
 target_link_libraries(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${SDK_TARGET_NAME})
@@ -66,14 +66,14 @@ set_property(TARGET ${INTEGRATION_TEST_TARGET_NAME} APPEND_STRING PROPERTY COMPI
 # Gather list of all .cert files in "/cert"
 add_custom_command(TARGET ${INTEGRATION_TEST_TARGET_NAME} PRE_BUILD
 		COMMAND ${CMAKE_COMMAND} -E
-		copy_directory ${CMAKE_SOURCE_DIR}/certs $<TARGET_FILE_DIR:${INTEGRATION_TEST_TARGET_NAME}>/certs)
+		copy_directory ${PROJECT_SOURCE_DIR}/../../certs $<TARGET_FILE_DIR:${INTEGRATION_TEST_TARGET_NAME}>/certs)
 
 if(MSVC)
-	target_sources(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/common/ConfigCommon.hpp)
-	source_group("Header Files\\Tests\\Integration" FILES ${CMAKE_SOURCE_DIR}/common/ConfigCommon.hpp)
-	source_group("Source Files\\Tests\\Integration" FILES ${CMAKE_SOURCE_DIR}/common/ConfigCommon.cpp)
+	target_sources(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.hpp)
+	source_group("Header Files\\Tests\\Integration" FILES ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.hpp)
+	source_group("Source Files\\Tests\\Integration" FILES ${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.cpp)
 
-	file(GLOB_RECURSE INTEGRATION_TEST_HEADERS FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/tests/integration/include/*.hpp)
+	file(GLOB_RECURSE INTEGRATION_TEST_HEADERS FOLLOW_SYMLINKS ${PROJECT_SOURCE_DIR}/include/*.hpp)
 	target_sources(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${INTEGRATION_TEST_HEADERS})
 	source_group("Header Files\\Tests\\Integration" FILES ${INTEGRATION_TEST_HEADERS})
 	source_group("Source Files\\Tests\\Integration" FILES ${INTEGRATION_TEST_SOURCES})
@@ -84,4 +84,4 @@ endif()
 #########################
 
 set(NETWORK_WRAPPER_DEST_TARGET ${INTEGRATION_TEST_TARGET_NAME})
-include(${CMAKE_SOURCE_DIR}/network/CMakeLists.txt.in)
+include(${PROJECT_SOURCE_DIR}/../../network/CMakeLists.txt.in)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -39,7 +39,7 @@ set(INTEGRATION_TEST_TARGET_NAME aws-iot-integration-tests)
 # Add Target
 add_executable(${INTEGRATION_TEST_TARGET_NAME} "${PROJECT_SOURCE_DIR}/../../common/ConfigCommon.cpp")
 
-target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
+target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/src/include)
 target_include_directories(${INTEGRATION_TEST_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../include)
 
 # Configure Threading library

--- a/tests/unit/CMakeLists-gtest.txt.in
+++ b/tests/unit/CMakeLists-gtest.txt.in
@@ -6,8 +6,8 @@ include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           master
-  SOURCE_DIR        "${CMAKE_BINARY_DIR}/third_party/googletest/src"
-  BINARY_DIR        "${CMAKE_BINARY_DIR}/third_party/googletest/build"
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/googletest/src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/googletest/build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -5,7 +5,7 @@ project(aws-iot-cpp-unit-tests CXX)
 # Section : Disable in-source builds #
 ######################################
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${CMAKE_CURRENT_LIST_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message( FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt and CMakeFiles folder." )
 endif()
 
@@ -41,7 +41,7 @@ set(UNIT_TEST_TARGET_NAME aws-iot-unit-tests)
 add_executable(${UNIT_TEST_TARGET_NAME} "")
 
 target_include_directories(${SDK_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
-target_include_directories(${SDK_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(${SDK_TARGET_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 # Configure Threading library
 find_package(Threads REQUIRED)
@@ -64,9 +64,9 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_BINARY_DIR}/third_party/googletest/src
 		${CMAKE_BINARY_DIR}/third_party/googletest/build)
 
-file(GLOB_RECURSE SDK_UNIT_TEST_SOURCES FOLLOW_SYMLINKS ${CMAKE_SOURCE_DIR}/tests/unit/src/*.cpp)
+file(GLOB_RECURSE SDK_UNIT_TEST_SOURCES FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/tests/unit/src/*.cpp)
 target_sources(${UNIT_TEST_TARGET_NAME} PUBLIC ${SDK_UNIT_TEST_SOURCES})
-target_include_directories(${UNIT_TEST_TARGET_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/tests/unit/include)
+target_include_directories(${UNIT_TEST_TARGET_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/tests/unit/include)
 target_link_libraries(${UNIT_TEST_TARGET_NAME} gtest gtest_main gmock gmock_main)
 target_link_libraries(${UNIT_TEST_TARGET_NAME} ${THREAD_LIBRARY_LINK_STRING})
 target_link_libraries(${UNIT_TEST_TARGET_NAME} ${SDK_TARGET_NAME})
@@ -111,7 +111,7 @@ endif()
 
 add_custom_command(TARGET ${UNIT_TEST_TARGET_NAME} PRE_BUILD
 		COMMAND ${CMAKE_COMMAND} -E
-		copy ${CMAKE_SOURCE_DIR}/tests/unit/src/util/TestParser.json $<TARGET_FILE_DIR:${UNIT_TEST_TARGET_NAME}>/TestParser.json)
+		copy ${CMAKE_CURRENT_LIST_DIR}/tests/unit/src/util/TestParser.json $<TARGET_FILE_DIR:${UNIT_TEST_TARGET_NAME}>/TestParser.json)
 
 set_property(TARGET ${UNIT_TEST_TARGET_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${CUSTOM_COMPILER_FLAGS})
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -40,7 +40,7 @@ enable_testing()
 set(UNIT_TEST_TARGET_NAME aws-iot-unit-tests)
 add_executable(${UNIT_TEST_TARGET_NAME} "")
 
-target_include_directories(${SDK_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/third_party/rapidjson/src/include)
+target_include_directories(${SDK_TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/rapidjson/src/include)
 target_include_directories(${SDK_TARGET_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 # Configure Threading library
@@ -49,20 +49,20 @@ target_link_libraries(${UNIT_TEST_TARGET_NAME} "Threads::Threads")
 
 # Download and unpack googletest at configure time
 configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists-gtest.txt.in
-		${CMAKE_BINARY_DIR}/third_party/googletest/download/CMakeLists.txt)
+		${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/googletest/download/CMakeLists.txt)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/third_party/googletest/download)
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/googletest/download)
 
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/third_party/googletest/download)
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/googletest/download)
 
 # Prevent GoogleTest from overriding compiler/linker options
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # This adds the following targets: gtest, gtest_main, gmock and gmock_main
-add_subdirectory(${CMAKE_BINARY_DIR}/third_party/googletest/src
-		${CMAKE_BINARY_DIR}/third_party/googletest/build)
+add_subdirectory(${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/googletest/src
+		${CMAKE_BINARY_DIR}/${DEPENDENCY_DIR}/googletest/build)
 
 file(GLOB_RECURSE SDK_UNIT_TEST_SOURCES FOLLOW_SYMLINKS ${CMAKE_CURRENT_LIST_DIR}/tests/unit/src/*.cpp)
 target_sources(${UNIT_TEST_TARGET_NAME} PUBLIC ${SDK_UNIT_TEST_SOURCES})


### PR DESCRIPTION

This change allows parent projects to determine where other dependencies should live by adding the following:

    set(DEPENDENCY_DIR "vendors")

The reason for this is that the aws-iot-device-sdk-cpp library is likely already being installed along with other project dependencies.  Currently aws-iot creates another directory at the top level of the parent project for it's dependencies.  This is probably not desired for projects with existing dependencies and existing directory structure for third-party libraries.

Another option may be to simply ensure that the aws-iot dependencies are downloading in a subdirectory relative to itself and not the parent project.

This patch was made on top of @larsonmpdx's branch, but is not dependent upon it.  I am happy to separate it out if necessary.
