### PR TITLE
Fix cyclic references.

### DIFF
--- a/include/ClientCoreState.hpp
+++ b/include/ClientCoreState.hpp
@@ -271,6 +271,22 @@ namespace awsiotsdk {
          */
         void DeleteExpiredAcks();
 
+	/**
+         * @brief Clears all registered Actions
+         *
+         * Utility method to remove all registered actions by the client.
+	 * Also helps in breaking out of cyclic reference introduced when ::RegisterAction is called.
+         */
+	void ClearRegisteredActions();
+
+	/**
+         * @brief Clears all pending outbound Actions.
+         *
+         * Utility method to remove all pending outbound actions registered by the client.
+	 * Also helps in breaking out of cyclic reference introduced when ::EnqueueOutboundAction is called.
+         */
+        void ClearOutboundActionQueue();
+
         /**
          * @brief Default Constructor
          */

--- a/src/ClientCoreState.cpp
+++ b/src/ClientCoreState.cpp
@@ -231,4 +231,12 @@ namespace awsiotsdk {
             pending_ack_map_.erase(itr);
         }
     }
+
+    void ClientCoreState::ClearRegisteredActions() {
+        action_map_.clear();
+    }
+
+    void ClientCoreState::ClearOutboundActionQueue() {
+        util::Queue<std::pair<ActionType, std::shared_ptr<ActionData>>>().swap(outbound_action_queue_);
+    }
 }

--- a/src/mqtt/Client.cpp
+++ b/src/mqtt/Client.cpp
@@ -218,6 +218,13 @@ namespace awsiotsdk {
                               ResponseHelper::ToString(rc).c_str());
             }
         }
+
+	// p_client_state_.action_map_ and p_client_state_.outbound_action_queue_ retains p_client_state_
+	// hence, calling p_client_state_->RegisterAction() or p_client_state_->EnqueueOutboundAction() introduces cyclic references inside p_client_state_
+	// make sure that p_client_state_.action_map_ and p_client_state_.outbound_action_queue_ are cleared prior to p_client_state_ destructor
+	// to break the cyclic references. 
+	p_client_state_->ClearRegisteredActions();
+	p_client_state_->ClearOutboundActionQueue();
     }
 }
 


### PR DESCRIPTION
Looks like ClientCoreState has cyclic references inside `action_map_` & `outbound_action_queue_` which will cause memory leak as reported in #23 . 

This hot-fix will resolve some of the issues reported.