### PR TITLE
fix compilation with -Werror=unused-result

### DIFF
--- a/common/ConfigCommon.cpp
+++ b/common/ConfigCommon.cpp
@@ -116,7 +116,8 @@ namespace awsiotsdk {
         util::String current_working_directory;
         {
             char CurrentWD[MAX_PATH_LENGTH_ + 1];
-            getcwd(CurrentWD, sizeof(CurrentWD));
+            if (getcwd(CurrentWD, sizeof(CurrentWD)) == NULL)
+                CurrentWD[0] = 0;
             current_working_directory.append(CurrentWD, strlen(CurrentWD));
         }
         return current_working_directory;


### PR DESCRIPTION
After upgrading to ubuntu artful (17.10) the new gcc seems to have -Werror=unused-result on by default which breaks compilation.

from man 2 getcwd:

`On failure, these functions return NULL, and errno is set to indicate the error.  The contents of the array pointed to by buf are undefined on error.`

Now, the interesting bit is that if I compare the result with NULL, it actually fails with `NULL used in arithmetic [-Werror=pointer-arith]` so checking for 0... Not sure if this is pretty enough, but at least gets around the issue and shouldn't do any wrong.