### PR TITLE
Implement static Shadow method GetEmptyShadowDocument

### DIFF
--- a/src/shadow/Shadow.cpp
+++ b/src/shadow/Shadow.cpp
@@ -160,7 +160,7 @@ namespace awsiotsdk {
         }
     }
 
-    util::JsonDocument GetEmptyShadowDocument() {
+    util::JsonDocument Shadow::GetEmptyShadowDocument() {
         util::JsonDocument empty_shadow_json_document;
         util::JsonParser::InitializeFromJsonString(empty_shadow_json_document, SHADOW_DOCUMENT_EMPTY_STRING);
         return std::move(empty_shadow_json_document);


### PR DESCRIPTION
`Shadow::` namespace was missing for static method `GetEmptyShadowDocument`