### PR TITLE
Aws SDK: Allow to work with OpenSSL 1.1.0

### DIFF
--- a/network/OpenSSL/OpenSSLConnection.cpp
+++ b/network/OpenSSL/OpenSSLConnection.cpp
@@ -41,7 +41,9 @@ namespace awsiotsdk {
     namespace network {
         OpenSSLInitializer::~OpenSSLInitializer() {
             CONF_modules_free();
-            ERR_remove_state(0);
+            #if OPENSSL_VERSION_NUMBER >= 0x10000000L && OPENSSL_VERSION_NUMBER < 0x10100000L
+            ERR_remove_thread_state(NULL);
+            #endif
             CONF_modules_unload(1);
             SSL_COMP_free_compression_methods();
             ERR_free_strings();
@@ -158,7 +160,7 @@ namespace awsiotsdk {
                 return ResponseCode::NETWORK_SSL_INIT_ERROR;
             }
 
-            method = TLSv1_2_method();
+            method = TLS_method();
 
             if ((p_ssl_context_ = SSL_CTX_new(method)) == NULL) {
                 AWS_LOG_ERROR(OPENSSL_WRAPPER_LOG_TAG, " SSL INIT Failed - Unable to create SSL Context");
@@ -492,7 +494,9 @@ namespace awsiotsdk {
             });
 
             SSL_free(p_ssl_handle_);
-            ERR_remove_state(0);
+            #if OPENSSL_VERSION_NUMBER >= 0x10000000L && OPENSSL_VERSION_NUMBER < 0x10100000L
+            ERR_remove_thread_state(NULL);
+            #endif
 
             certificates_read_flag_ = false;
 #ifdef WIN32


### PR DESCRIPTION
* Wrapped the remove_thread calls in an ifdef.
* Made change to use version-independent call to TLS_method per old issue: https://github.com/aws/aws-iot-device-sdk-cpp/pull/19, that was suggested to be in next version of AWS (but was missed?)
* This possibly resolves issue: https://github.com/aws/aws-iot-device-sdk-cpp/issues/44, which I opened to track this. 
* With these changes in place and OpenSSL 1.1.0f, it was able to connect and IoT messages flowed in both directions. 