### PR TITLE
Fix a bug where keep-alive thread never reconnects.

### DIFF
--- a/src/mqtt/Connect.cpp
+++ b/src/mqtt/Connect.cpp
@@ -588,6 +588,11 @@ namespace awsiotsdk {
 
                         p_client_state_->SetPingreqPending(true);
                         next = std::chrono::system_clock::now() + std::chrono::seconds(keep_alive_interval);
+                    } else if (!p_client_state_->IsConnected()) {
+                        // its PING time, but for some reason the client got disconnected.
+                        // make sure that we reconnect (if auto reconnect is enabled) ASAP.
+                        p_client_state_->SetAutoReconnectRequired(true);
+                        continue;
                     }
                 }
                 std::this_thread::sleep_for(thread_sleep_duration);


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
Hello,

While testing, I found a case where the Keep-Alive thread (with auto reconnect enabled) will never reconnect the client.

Here's the sequence:
1. connect the client once
2. call subscribe to any valid topic -> subscribe OK
3. disconnect WiFi
4. Keep-Alive thread will send PING after sometime and would fail -> kicking the reconnect logic.
5. Reconnect attempt will fail since WiFi is disconnected but Keep-Alive thread will retry.
6. connect WiFi
7. Reconnect succeeds -> [reconnect callback is called](https://github.com/aws/aws-iot-device-sdk-cpp/blob/master/src/mqtt/Connect.cpp#L467).
8. disconnect WiFi again (since this is manual operation, you may want to sleep inside the reconnect callback)
9. Keep-Alive thread tries to resubscribe but fails since WiFi is disconnected.
10. Since reconnect was successful but resubscribe failed, [Keep-Alive thread disconnects the client](https://github.com/aws/aws-iot-device-sdk-cpp/blob/master/src/mqtt/Connect.cpp#L520) hoping that the reconnect logic would kick in soon.

Reconnect logic never kicked in from that point.
(I must confess that I am still not 100% sure about the actual cause for this; maybe you guys can shed some light here)

I was able to reproduce this situation with PubSub sample after some modifications. (let me know if I should attach the sample I tried)
To make step 8 simple, I disconnected the client inside the reconnect callback by calling `Disconnect()` api.

This fix will make sure that the Keep-Alive thread will try to reconnect if client was found disconnected during PING time. 

Why during PING time?
Because Keep-Alive thread continuously sends PING and hence such not so common reconnect failure errors can be caught there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Thanks
