### PR TITLE
Added nullptr initialization for frame context.

### DIFF
--- a/network/WebSocket/WebSocketConnection.cpp
+++ b/network/WebSocket/WebSocketConnection.cpp
@@ -130,6 +130,7 @@ namespace awsiotsdk {
             p_wslay_frame_Callbacks_->genmask_callback = std::bind(&WebSocketConnection::WssFrameGenMaskCallback, this,
                                                                    std::placeholders::_1, std::placeholders::_2,
                                                                    std::placeholders::_3);
+            p_wslay_frame_Context_ = nullptr;
 
             wss_frame_read_ = std::unique_ptr<wslay_frame_iocb>(new wslay_frame_iocb());
             wss_frame_write_ = std::unique_ptr<wslay_frame_iocb>(new wslay_frame_iocb());


### PR DESCRIPTION
Description of changes: If a `WebSocketConnection` was deleted without calling connect it resulted in a crash in dlfree. Added a initialisation of `p_wslay_frame_Context_` as nullptr within the `WebSocketConnection` constructor to fix this crash.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.