### PR TITLE
Fix keep-alive thread resubscribe

### DIFF
--- a/src/mqtt/Connect.cpp
+++ b/src/mqtt/Connect.cpp
@@ -484,7 +484,10 @@ namespace awsiotsdk {
                                     std::shared_ptr<mqtt::SubscribePacket>
                                         p_subscribe_packet = mqtt::SubscribePacket::Create(topic_vector);
                                     p_subscribe_packet->SetPacketId(p_client_state_->GetNextPacketId());
-                                    rc = WriteToNetworkBuffer(p_network_connection, p_subscribe_packet->ToString());
+
+                                    rc = p_client_state_->PerformAction(ActionType::SUBSCRIBE,
+                                                                        p_subscribe_packet,
+                                                                        p_client_state_->GetMqttCommandTimeout());
                                     if (ResponseCode::SUCCESS != rc) {
                                         AWS_LOG_ERROR(KEEPALIVE_LOG_TAG,
                                                       "Resubscribe attempt returned unhandled error. \n%s",
@@ -500,7 +503,10 @@ namespace awsiotsdk {
                                     std::shared_ptr<mqtt::SubscribePacket>
                                         p_subscribe_packet = mqtt::SubscribePacket::Create(topic_vector);
                                     p_subscribe_packet->SetPacketId(p_client_state_->GetNextPacketId());
-                                    rc = WriteToNetworkBuffer(p_network_connection, p_subscribe_packet->ToString());
+
+                                    rc = p_client_state_->PerformAction(ActionType::SUBSCRIBE,
+                                                                        p_subscribe_packet,
+                                                                        p_client_state_->GetMqttCommandTimeout());
                                 }
                             }
 


### PR DESCRIPTION
Fixes a bug where keep-alive thread would call resubscribe callback without waiting for subscribe to actually complete.

*Description of changes:*

Keep-alive thread auto-reconnect sequence:

Actual:
- call disconnect callback
- Try connect => connect OK (waits for ACK)
- call reconnect callback
- subscribe topics => subscribe OK (**does not wait for ACK**)
- call resubscribe callback

Expectation:
- call disconnect callback
- Try connect => connect OK (waits for ACK)
- call reconnect callback
- subscribe topics => subscribe OK (**waits for ACK**)
- call resubscribe callback

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
