### PR TITLE
Fix shadow delta callback handler

### DIFF
--- a/src/shadow/Shadow.cpp
+++ b/src/shadow/Shadow.cpp
@@ -266,11 +266,16 @@ namespace awsiotsdk {
             }
         }
 
+        ShadowRequestType shadow_req_type = ShadowRequestType::Update;
+        if (ShadowResponseType::Delta == response_type) {
+            shadow_req_type = ShadowRequestType::Delta;
+        }
+
         util::Map<ShadowRequestType, RequestHandlerPtr>::iterator request_itr
-            = request_mapping_.find(ShadowRequestType::Update);
+            = request_mapping_.find(shadow_req_type);
         if (request_itr != request_mapping_.end() && nullptr != request_itr->second) {
             RequestHandlerPtr ptr = request_itr->second;
-            ResponseCode rc_handler = ptr(thing_name_, ShadowRequestType::Update, response_type, payload);
+            ResponseCode rc_handler = ptr(thing_name_, shadow_req_type, response_type, payload);
             IOT_UNUSED(rc_handler);
         }
 


### PR DESCRIPTION
Fixes a bug where shadow client will not call the configured delta callback handler. It instead calls Update callback.

*Description of changes:*

Actual:
- Application registers shadow request callback handlers (with `Shadow::AddShadowSubscription` api) as follows:
  - Update callback handler => U
  - Delta callback handler => D
- On update (accepted or rejected), U is called.
- **On delta, U is called (instead of D).**

Expectation:
- Application registers shadow request callback handlers (with `Shadow::AddShadowSubscription` api) as follows:
  - Update callback handler => U
  - Delta callback handler => D
- On update (accepted or rejected), U is called.
- **On delta, D is called.**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
