### PR TITLE
Use `std::chrono::steady_clock` where appropriate.

### DIFF
--- a/include/ClientCoreState.hpp
+++ b/include/ClientCoreState.hpp
@@ -100,7 +100,7 @@ namespace awsiotsdk {
          */
         class PendingAckData {
         public:
-            std::chrono::system_clock::time_point time_of_request_;           ///< Time at which the request was sent
+            std::chrono::steady_clock::time_point time_of_request_;           ///< Time at which the request was sent
             ActionData::AsyncAckNotificationHandlerPtr p_async_ack_handler_;  ///< Handler to which response must be sent
         };
 

--- a/network/MbedTLS/MbedTLSConnection.cpp
+++ b/network/MbedTLS/MbedTLSConnection.cpp
@@ -283,7 +283,7 @@ namespace awsiotsdk {
             bool isErrorFlag = false;
             int ret;
 
-            const auto start = std::chrono::system_clock::now();
+            const auto start = std::chrono::steady_clock::now();
             auto elapsed_time = std::chrono::duration<double>();
 
             do {
@@ -297,7 +297,7 @@ namespace awsiotsdk {
                     isErrorFlag = true;
                     break;
                 }
-                elapsed_time = std::chrono::system_clock::now() - start;
+                elapsed_time = std::chrono::steady_clock::now() - start;
             } while (tls_write_timeout_ > std::chrono::duration_cast<std::chrono::milliseconds>(elapsed_time) &&
                     total_written_length < bytes_to_write);
 
@@ -318,7 +318,7 @@ namespace awsiotsdk {
             int ret;
             size_t total_read_length = 0;
             size_t remaining_bytes_to_read = size_bytes_to_read;
-            const auto start = std::chrono::system_clock::now();
+            const auto start = std::chrono::steady_clock::now();
             auto elapsed_time = std::chrono::duration<double>();
             do {
                 // This read will timeout after IOT_SSL_READ_TIMEOUT if there's no data to be read
@@ -332,7 +332,7 @@ namespace awsiotsdk {
                     && ret != MBEDTLS_ERR_SSL_TIMEOUT) {
                     return ResponseCode::NETWORK_SSL_READ_ERROR;
                 }
-                elapsed_time = std::chrono::system_clock::now() - start;
+                elapsed_time = std::chrono::steady_clock::now() - start;
             } while (remaining_bytes_to_read > 0 &&
                     tls_read_timeout_ > std::chrono::duration_cast<std::chrono::milliseconds>(elapsed_time));
 

--- a/src/ClientCoreState.cpp
+++ b/src/ClientCoreState.cpp
@@ -140,7 +140,7 @@ namespace awsiotsdk {
                 continue;
             }
             std::lock_guard<std::mutex> sync_action_lock(sync_action_request_lock_);
-            auto next = std::chrono::system_clock::now() + std::chrono::milliseconds(action_execution_delay);
+            auto next = std::chrono::steady_clock::now() + std::chrono::milliseconds(action_execution_delay);
             ActionType action_type = outbound_action_queue_.front().first;
             std::shared_ptr<ActionData> p_action_data = outbound_action_queue_.front().second;
 
@@ -193,7 +193,7 @@ namespace awsiotsdk {
 
         std::unique_ptr<PendingAckData> p_pending_ack_data = std::unique_ptr<PendingAckData>(new PendingAckData());
         p_pending_ack_data->p_async_ack_handler_ = p_async_ack_handler;
-        p_pending_ack_data->time_of_request_ = std::chrono::system_clock::now();
+        p_pending_ack_data->time_of_request_ = std::chrono::steady_clock::now();
 
         std::lock_guard<std::mutex> sync_action_lock(ack_map_lock_);
         pending_ack_map_.insert(std::make_pair(action_id, std::move(p_pending_ack_data)));
@@ -210,7 +210,7 @@ namespace awsiotsdk {
 
     void ClientCoreState::DeleteExpiredAcks() {
         std::lock_guard<std::mutex> sync_action_lock(ack_map_lock_);
-        std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+        std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
         util::Map<uint16_t, std::unique_ptr<PendingAckData>>::const_iterator itr = pending_ack_map_.begin();
         while (itr != pending_ack_map_.end()) {
             std::chrono::seconds diff = std::chrono::duration_cast<std::chrono::seconds>(

--- a/src/mqtt/Connect.cpp
+++ b/src/mqtt/Connect.cpp
@@ -358,7 +358,6 @@ namespace awsiotsdk {
 
             //Ignore error codes, always assume disconnect
             p_client_state_->SetConnected(false);
-
             ResponseCode rc = ResponseCode::SUCCESS;
 
             // Attempt to send MQTT Disconnect if Network is still connected
@@ -429,7 +428,7 @@ namespace awsiotsdk {
             std::chrono::seconds reconnect_backoff_timer = p_client_state_->GetMinReconnectBackoffTimeout();
             std::chrono::seconds max_backoff_value = p_client_state_->GetMaxReconnectBackoffTimeout();
             std::chrono::seconds keep_alive_interval = p_client_state_->GetKeepAliveTimeout() / 2;
-            auto next = std::chrono::system_clock::now() + std::chrono::seconds(keep_alive_interval);
+            auto next = std::chrono::steady_clock::now() + std::chrono::seconds(keep_alive_interval);
 
             do {
                 if (p_client_state_->IsAutoReconnectEnabled() && p_client_state_->IsAutoReconnectRequired()) {
@@ -554,7 +553,7 @@ namespace awsiotsdk {
                     }
                 }
 
-                if (std::chrono::system_clock::now() > next) {
+                if (std::chrono::steady_clock::now() > next) {
                     if (p_client_state_->IsPingreqPending()) {
                         if (p_client_state_->IsConnected()) {
                             rc = p_client_state_->PerformAction(ActionType::DISCONNECT,
@@ -588,7 +587,7 @@ namespace awsiotsdk {
                         }
 
                         p_client_state_->SetPingreqPending(true);
-                        next = std::chrono::system_clock::now() + std::chrono::seconds(keep_alive_interval);
+                        next = std::chrono::steady_clock::now() + std::chrono::seconds(keep_alive_interval);
                     }
                 }
                 std::this_thread::sleep_for(thread_sleep_duration);


### PR DESCRIPTION
*Issue:*
#125

*Description of changes:*
Use `std::chrono::steady_clock` for things that measure how much time has passed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
