### PR TITLE
Re-read SSL ca certificates when reconnecting after timeout

### DIFF
--- a/network/OpenSSL/OpenSSLConnection.cpp
+++ b/network/OpenSSL/OpenSSLConnection.cpp
@@ -192,6 +192,9 @@ namespace awsiotsdk {
                 return ResponseCode::NETWORK_SSL_INIT_ERROR;
             }
 
+            // Certificates must be read again when resetting `p_ssl_context_`
+            certificates_read_flag_ = false;
+
             return ResponseCode::SUCCESS;
         }
 


### PR DESCRIPTION
*Issue: #129 - Test case 2*

*Description of changes:*
After a timeout, the ssl context in `network/OpenSSL/OpenSSLConnection.cpp` is reset.
This means the ca certificates loaded by `OpenSSLConnection::LoadCerts` must be loaded again.
Resetting the `certificates_read_flag` when clearing the ssl context triggers this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
