### PR TITLE
Adding support for absolute paths in ConfigCommon

### DIFF
--- a/common/ConfigCommon.hpp
+++ b/common/ConfigCommon.hpp
@@ -64,7 +64,13 @@ namespace awsiotsdk {
         static uint32_t action_processing_rate_hz_;
 
         static ResponseCode InitializeCommon(const util::String &config_file_path);
+        static ResponseCode InitializeCommon(const util::String &config_absolute_path,
+                                             const util::String &config_file);
         static util::String GetCurrentPath();
+
+    private:
+        static ResponseCode PopulateCommon(const util::String &config_absolute_path,
+                                           const util::String &config_file);
     };
 }
 


### PR DESCRIPTION
Added second InitializeCommon function that will take in an absolute path, rather than relying on using current working directory.

Created common function PopulateCommon that both InitializeCommon functions will call.

fixed compiler warning for LogParseError

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
