### PR TITLE
Remove pending ACK when subscription was already successful for a topic.

### DIFF
--- a/src/mqtt/Subscribe.cpp
+++ b/src/mqtt/Subscribe.cpp
@@ -253,6 +253,9 @@ namespace awsiotsdk {
                 if (p_client_state_->subscription_map_.end() != existing_itr) {
                     if (existing_itr->second->IsActive()) {
                         itr = p_subscribe_packet->subscription_list_.erase(itr);
+                        if (is_ack_registered) {
+                            p_client_state_->DeletePendingAck(packet_id);
+                        }
                         // TODO: This needs to be reworked
                         continue;
                     } else {
@@ -267,7 +270,9 @@ namespace awsiotsdk {
             }
 
             const util::String packet_data = p_subscribe_packet->ToString();
-            rc = WriteToNetworkBuffer(p_network_connection, packet_data);
+            if (p_subscribe_packet->subscription_list_.size() > 0) {
+                rc = WriteToNetworkBuffer(p_network_connection, packet_data);
+            }
             if (ResponseCode::SUCCESS != rc) {
                 AWS_LOG_ERROR(SUBSCRIBE_ACTION_LOG_TAG, "Subscribe Write to Network Failed. %s",
                               ResponseHelper::ToString(rc).c_str());


### PR DESCRIPTION
#61

Fixing multiple subscribe attempts on already subscribed topic.
Remove pending ack when an already subscribed topic is detected.
Don't write to network when subscription list is empty.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
