### PR TITLE
Fix GCC unused result warning in JobAgent sample

### DIFF
--- a/samples/JobsAgent/JobsAgentOperations.cpp
+++ b/samples/JobsAgent/JobsAgentOperations.cpp
@@ -636,7 +636,8 @@ namespace awsiotsdk {
                                 // User account running agent must have passwordless sudo access on /sbin/shutdown
                                 // Recommended online search for permissions setup instructions https://www.google.com/search?q=passwordless+sudo+access+instructions
                                 systemCommand = GetShutdownSystemCommand(false, operation == "reboot");
-                                system(systemCommand.c_str());
+                                int rc = system(systemCommand.c_str());
+                                IOT_UNUSED(rc);
                                 std::cout << std::endl << outputMessage << std::endl;
                             }
                         }


### PR DESCRIPTION
This change is to fix a GCC `unused-result` warning when I was building
the JobAgent sample. The return value from the `system` call isn't used.
I am using Ubuntu 19.04 and GCC 8.3.0.

```
aws-iot-device-sdk-cpp/samples/JobsAgent/JobsAgentOperations.cpp: In member function ‘awsiotsdk::ResponseCode awsiotsdk::samples::JobsAgent::UpdateAcceptedCallback(awsiotsdk::util::String, awsiotsdk::util::String, std::shared_ptr<awsiotsdk::mqtt::SubscriptionHandlerContextData>)’:
aws-iot-device-sdk-cpp/samples/JobsAgent/JobsAgentOperations.cpp:639:39: error: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Werror=unused-result]
                                 system(systemCommand.c_str());
                                 ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [tests/unit/CMakeFiles/aws-iot-unit-tests.dir/build.make:63: tests/unit/CMakeFiles/aws-iot-unit-tests.dir/__/__/samples/JobsAgent/JobsAgentOperations.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:244: tests/unit/CMakeFiles/aws-iot-unit-tests.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
