### PR TITLE
Hotfix shadow invalid publish

### DIFF
--- a/src/shadow/Shadow.cpp
+++ b/src/shadow/Shadow.cpp
@@ -577,6 +577,11 @@ namespace awsiotsdk {
             diff.EraseMember(SHADOW_DOCUMENT_VERSION_KEY);
         }
 
+        // make sure that payload is valid
+        if (!diff.HasMember(SHADOW_DOCUMENT_STATE_KEY)) {
+            return ResponseCode::SHADOW_NOTHING_TO_UPDATE;
+        }
+
         util::String payload = util::JsonParser::ToString(diff);
 
         rc = p_mqtt_client_->Publish(Utf8String::Create(shadow_topic_update_), false, false, mqtt::QoS::QOS0,


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-iot-device-sdk-cpp/issues/168

*Description of changes:*

Fixes a bug where [Shadow::PerformUpdateAsync()](https://github.com/aws/aws-iot-device-sdk-cpp/blob/master/src/shadow/Shadow.cpp#L537) will update shadow without `state` node.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
