### PR TITLE
Clean up defaulted copy and move ctors, fixes #170

### DIFF
--- a/include/discovery/Discovery.hpp
+++ b/include/discovery/Discovery.hpp
@@ -44,21 +44,16 @@ namespace awsiotsdk {
 
         public:
             DiscoveryResponse discovery_response_;              ///< Response received in Discover request
-            // Ensure Default and Copy Constructors and Copy assignment operator are deleted
-            // Use default move constructors and assignment operators
-            // Default virtual destructor
+
+            // Rule of 5 stuff
+            // Disable copying and moving because class contains DiscoveryResponse
             // Delete Default constructor
-            DiscoverRequestData() = delete;
-            // Delete Copy constructor
-            DiscoverRequestData(const DiscoverRequestData &) = delete;
-            // Default Move constructor
-            DiscoverRequestData(DiscoverRequestData &&) = default;
-            // Delete Copy assignment operator
-            DiscoverRequestData &operator=(const DiscoverRequestData &) & = delete;
-            // Default Move assignment operator
-            DiscoverRequestData &operator=(DiscoverRequestData &&) & = default;
-            // Default destructor
-            virtual ~DiscoverRequestData() = default;
+            DiscoverRequestData() = delete;                                         // Default constructor
+            DiscoverRequestData(const DiscoverRequestData &) = delete;              // Copy constructor
+            DiscoverRequestData(DiscoverRequestData &&) = delete;                   // Move constructor
+            DiscoverRequestData &operator=(const DiscoverRequestData &) & = delete; // Copy assignment operator
+            DiscoverRequestData &operator=(DiscoverRequestData &&) & = delete;      // Move assignment operator
+            virtual ~DiscoverRequestData() = default;                               // Default destructor
 
             /**
              * @brief Constructor

--- a/include/mqtt/ClientState.hpp
+++ b/include/mqtt/ClientState.hpp
@@ -56,12 +56,12 @@ namespace awsiotsdk {
             util::Map<util::String, std::shared_ptr<Subscription>> subscription_map_;
 
             // Rule of 5 stuff
-            // Disable copying because class contains std::atomic<> types used for thread synchronization
+            // Disable copying and moving because class contains std::atomic<> types used for thread synchronization
             ClientState() = delete;                                  // Default constructor
             ClientState(const ClientState &) = delete;               // Delete Copy constructor
-            ClientState(ClientState &&) = default;                   // Move constructor
+            ClientState(ClientState &&) = delete;                    // Move constructor
             ClientState &operator=(const ClientState &) & = delete;  // Delete Copy assignment operator
-            ClientState &operator=(ClientState &&) & = default;      // Move assignment operator
+            ClientState &operator=(ClientState &&) & = delete;       // Move assignment operator
             ~ClientState() = default;                                // Default destructor
 
             ClientState(std::chrono::milliseconds mqtt_command_timeout);

--- a/include/mqtt/Connect.hpp
+++ b/include/mqtt/Connect.hpp
@@ -59,21 +59,14 @@ namespace awsiotsdk {
             //std::unique_ptr<Utf8String> p_password_;   ///< MQTT Password
 
         public:
-            // Ensure Default and Copy Constructors and Copy assignment operator are deleted
-            // Use default move constructors and assignment operators
-            // Default virtual destructor
-            // Delete Default constructor
-            ConnectPacket() = delete;
-            // Delete Copy constructor
-            ConnectPacket(const ConnectPacket &) = delete;
-            // Default Move constructor
-            ConnectPacket(ConnectPacket &&) = default;
-            // Delete Copy assignment operator
-            ConnectPacket &operator=(const ConnectPacket &) & = delete;
-            // Default Move assignment operator
-            ConnectPacket &operator=(ConnectPacket &&) & = default;
-            // Default destructor
-            virtual ~ConnectPacket() = default;
+            // Ensure Default Constructor is deleted
+            // Disabling default, move and copy constructors to match Packet parent
+            ConnectPacket() = delete;                                   // Default constructor
+            ConnectPacket(const ConnectPacket &) = delete;              // Copy constructor
+            ConnectPacket(ConnectPacket &&) = delete;                   // Move constructor
+            ConnectPacket &operator=(const ConnectPacket &) & = delete; // Copy assignment operator
+            ConnectPacket &operator=(ConnectPacket &&) & = delete;      // Move assignment operator
+            virtual ~ConnectPacket() = default;                         // Default destructor
 
             /**
              * @brief Constructor
@@ -185,17 +178,12 @@ namespace awsiotsdk {
          */
         class DisconnectPacket : public Packet {
         public:
-            // Ensure Default move and copy constructors and assignment operators are created
-            // Default virtual destructor
-            DisconnectPacket(const DisconnectPacket &) = default;
-            // Default Move constructor
-            DisconnectPacket(DisconnectPacket &&) = default;
-            // Default Copy assignment operator
-            DisconnectPacket &operator=(const DisconnectPacket &) & = default;
-            // Default Move assignment operator
-            DisconnectPacket &operator=(DisconnectPacket &&) & = default;
-            // Default destructor
-            virtual ~DisconnectPacket() = default;
+            // Disabling default, move and copy constructors to match Packet parent
+            DisconnectPacket(const DisconnectPacket &) = delete;                // Copy constructor
+            DisconnectPacket(DisconnectPacket &&) = delete;                     // Move constructor
+            DisconnectPacket &operator=(const DisconnectPacket &) & = delete;   // Copy assignment operator
+            DisconnectPacket &operator=(DisconnectPacket &&) & = delete;        // Move assignment operator
+            virtual ~DisconnectPacket() = default;                              // Default destructor
 
             /**
              * @brief Constructor
@@ -218,18 +206,12 @@ namespace awsiotsdk {
 
         class PingreqPacket : public Packet {
         public:
-            // Ensure Default move and copy constructors and assignment operators are created
-            // Default virtual destructor
-            // Default Copy constructor
-            PingreqPacket(const PingreqPacket &) = default;
-            // Default Move constructor
-            PingreqPacket(PingreqPacket &&) = default;
-            // Default Copy assignment operator
-            PingreqPacket &operator=(const PingreqPacket &) & = default;
-            // Default Move assignment operator
-            PingreqPacket &operator=(PingreqPacket &&) & = default;
-            // Default destructor
-            virtual ~PingreqPacket() = default;
+            // Disabling default, move and copy constructors to match Packet parent
+            PingreqPacket(const PingreqPacket &) = delete;              // Copy constructor
+            PingreqPacket(PingreqPacket &&) = delete;                   // Move constructor
+            PingreqPacket &operator=(const PingreqPacket &) & = delete; // Copy assignment operator
+            PingreqPacket &operator=(PingreqPacket &&) & = delete;      // Move assignment operator
+            virtual ~PingreqPacket() = default;                         // Default destructor
 
             /**
              * @brief Constructor

--- a/include/mqtt/Packet.hpp
+++ b/include/mqtt/Packet.hpp
@@ -118,6 +118,15 @@ namespace awsiotsdk {
             std::atomic_uint_fast16_t packet_id_;  ///< Message sequence identifier.  Handled automatically by the MQTT client
 
         public:
+            // Rule of 5 stuff
+            // Disable copying and moving because class contains std::atomic<> types used for thread synchronization
+            Packet() = default;                             // Default constructor
+            Packet(const Packet &) = delete;                // Copy constructor
+            Packet(Packet &&) = delete;                     // Move constructor
+            Packet &operator=(const Packet &) & = delete;   // Copy assignment operator
+            Packet &operator=(Packet &&) & = delete;        // Move assignment operator
+            virtual ~Packet() = default;                    // Default destructor
+
             uint16_t GetActionId() { return (uint16_t) packet_id_.load(std::memory_order_relaxed); }
             void SetActionId(uint16_t action_id) { packet_id_.store(action_id, std::memory_order_relaxed); }
             bool isPacketDataValid();
@@ -136,7 +145,6 @@ namespace awsiotsdk {
                                                                         size_t &extract_index);
 
             virtual util::String ToString() = 0;
-            virtual ~Packet() {}
         };
     }
 }

--- a/include/mqtt/Publish.hpp
+++ b/include/mqtt/Publish.hpp
@@ -41,21 +41,14 @@ namespace awsiotsdk {
             std::unique_ptr<Utf8String> p_topic_name_;  ///< Topic Name this packet was published to
             util::String payload_;                      ///< MQTT message payload
         public:
-            // Ensure Default and Copy Constructors and Copy assignment operator are deleted
-            // Use default move constructors and assignment operators
-            // Default virtual destructor
-            // Delete Default constructor
-            PublishPacket() = delete;
-            // Delete Copy constructor
-            PublishPacket(const PublishPacket &) = delete;
-            // Default Move constructor
-            PublishPacket(PublishPacket &&) = default;
-            // Delete Copy assignment operator
-            PublishPacket &operator=(const PublishPacket &) & = delete;
-            // Default Move assignment operator
-            PublishPacket &operator=(PublishPacket &&) & = default;
-            // Default destructor
-            virtual ~PublishPacket() = default;
+            // Ensure Default Constructor is deleted
+            // Disabling default, move and copy constructors to match Packet parent
+            PublishPacket() = delete;                                   // Default constructor
+            PublishPacket(const PublishPacket &) = delete;              // Copy constructor
+            PublishPacket(PublishPacket &&) = delete;                   // Move constructor
+            PublishPacket &operator=(const PublishPacket &) & = delete; // Copy assignment operator
+            PublishPacket &operator=(PublishPacket &&) & = delete;      // Move assignment operator
+            virtual ~PublishPacket() = default;                         // Default destructor
 
             /**
              * @brief Constructor, Individual data
@@ -166,20 +159,14 @@ namespace awsiotsdk {
         protected:
             std::atomic_uint_fast16_t publish_packet_id_;
         public:
-            // Ensure Default Constructor is deleted, default to move and copy constructors and assignment operators
-            // Default virtual destructor
-            // Delete Default constructor
-            PubackPacket() = delete;
-            // Default Copy constructor
-            PubackPacket(const PubackPacket &) = default;
-            // Default Move constructor
-            PubackPacket(PubackPacket &&) = default;
-            // Default Copy assignment operator
-            PubackPacket &operator=(const PubackPacket &) & = default;
-            // Default Move assignment operator
-            PubackPacket &operator=(PubackPacket &&) & = default;
-            // Default destructor
-            virtual ~PubackPacket() = default;
+            // Ensure Default Constructor is deleted
+            // Disabling default, move and copy constructors to match Packet parent
+            PubackPacket() = delete;                                    // Default constructor
+            PubackPacket(const PubackPacket &) = delete;                // Copy constructor
+            PubackPacket(PubackPacket &&) = delete;                     // Move constructor
+            PubackPacket &operator=(const PubackPacket &) & = delete;   // Copy assignment operator
+            PubackPacket &operator=(PubackPacket &&) & = delete;        // Move assignment operator
+            virtual ~PubackPacket() = default;                          // Default destructor
 
             /**
              * @brief Constructor
@@ -218,13 +205,13 @@ namespace awsiotsdk {
             // Disabling default, move and copy constructors to match Action parent
             // Default virtual destructor
             PublishActionAsync() = delete;
-            // Default Copy constructor
+            // Delete Copy constructor
             PublishActionAsync(const PublishActionAsync &) = delete;
-            // Default Move constructor
+            // Delete Move constructor
             PublishActionAsync(PublishActionAsync &&) = delete;
-            // Default Copy assignment operator
+            // Delete Copy assignment operator
             PublishActionAsync &operator=(const PublishActionAsync &) & = delete;
-            // Default Move assignment operator
+            // Delete Move assignment operator
             PublishActionAsync &operator=(PublishActionAsync &&) & = delete;
             // Default destructor
             virtual ~PublishActionAsync() = default;
@@ -272,15 +259,14 @@ namespace awsiotsdk {
             std::shared_ptr<ClientState> p_client_state_;  ///< Shared Client State instance
         public:
             // Disabling default, move and copy constructors to match Action parent
-            // Default virtual destructor
             PubackActionAsync() = delete;
-            // Default Copy constructor
+            // Delete Copy constructor
             PubackActionAsync(const PubackActionAsync &) = delete;
-            // Default Move constructor
+            // Delete Move constructor
             PubackActionAsync(PubackActionAsync &&) = delete;
-            // Default Copy assignment operator
+            // Delete Copy assignment operator
             PubackActionAsync &operator=(const PubackActionAsync &) & = delete;
-            // Default Move assignment operator
+            // Delete Move assignment operator
             PubackActionAsync &operator=(PubackActionAsync &&) & = delete;
             // Default destructor
             virtual ~PubackActionAsync() = default;

--- a/include/mqtt/Subscribe.hpp
+++ b/include/mqtt/Subscribe.hpp
@@ -42,20 +42,14 @@ namespace awsiotsdk {
             util::Vector <std::shared_ptr<Subscription>>
                 subscription_list_;  ///< Vector containing subscriptions included in this packet
 
-            // Ensure Default Constructor is deleted, default to move and copy constructors and assignment operators
-            // Default virtual destructor
-            // Delete Default constructor
-            SubscribePacket() = delete;
-            // Default Copy constructor
-            SubscribePacket(const SubscribePacket &) = default;
-            // Default Move constructor
-            SubscribePacket(SubscribePacket &&) = default;
-            // Default Copy assignment operator
-            SubscribePacket &operator=(const SubscribePacket &) & = default;
-            // Default Move assignment operator
-            SubscribePacket &operator=(SubscribePacket &&) & = default;
-            // Default destructor
-            virtual ~SubscribePacket() = default;
+            // Ensure Default Constructor is deleted
+            // Disabling default, move and copy constructors to match Packet parent
+            SubscribePacket() = delete;                                     // Default constructor
+            SubscribePacket(const SubscribePacket &) = delete;              // Copy constructor
+            SubscribePacket(SubscribePacket &&) = delete;                   // Move constructor
+            SubscribePacket &operator=(const SubscribePacket &) & = delete; // Copy assignment operator
+            SubscribePacket &operator=(SubscribePacket &&) & = delete;      // Move assignment operator
+            virtual ~SubscribePacket() = default;                           // Default destructor
 
             /**
              * @brief Constructor
@@ -91,20 +85,14 @@ namespace awsiotsdk {
             // Public to avoid extra move/copy operations when in use by action
             util::Vector <uint8_t> suback_list_;  ///< Vector containing subacks included in this packet
 
-            // Ensure Default Constructor is deleted, default to move and copy constructors and assignment operators
-            // Default virtual destructor
-            // Delete Default constructor
-            SubackPacket() = delete;
-            // Default Copy constructor
-            SubackPacket(const SubackPacket &) = default;
-            // Default Move constructor
-            SubackPacket(SubackPacket &&) = default;
-            // Default Copy assignment operator
-            SubackPacket &operator=(const SubackPacket &) & = default;
-            // Default Move assignment operator
-            SubackPacket &operator=(SubackPacket &&) & = default;
-            // Default destructor
-            virtual ~SubackPacket() = default;
+            // Ensure Default Constructor is deleted
+            // Disabling default, move and copy constructors to match Packet parent
+            SubackPacket() = delete;                                    // Default constructor
+            SubackPacket(const SubackPacket &) = delete;                // Copy constructor
+            SubackPacket(SubackPacket &&) = delete;                     // Move constructor
+            SubackPacket &operator=(const SubackPacket &) & = delete;   // Copy assignment operator
+            SubackPacket &operator=(SubackPacket &&) & = delete;        // Move assignment operator
+            virtual ~SubackPacket() = default;                          // Default destructor
 
             /**
              * @brief Constructor
@@ -139,20 +127,15 @@ namespace awsiotsdk {
         public:
             // Public to avoid copying/returning reference in Unsubscribe Action
             util::Vector <std::unique_ptr<Utf8String>> topic_list_;
-            // Ensure Default Constructor is deleted, default to move and copy constructors and assignment operators
-            // Default virtual destructor
-            // Delete Default constructor
-            UnsubscribePacket() = delete;
-            // Default Copy constructor
-            UnsubscribePacket(const UnsubscribePacket &) = default;
-            // Default Move constructor
-            UnsubscribePacket(UnsubscribePacket &&) = default;
-            // Default Copy assignment operator
-            UnsubscribePacket &operator=(const UnsubscribePacket &) & = default;
-            // Default Move assignment operator
-            UnsubscribePacket &operator=(UnsubscribePacket &&) & = default;
-            // Default destructor
-            virtual ~UnsubscribePacket() = default;
+
+            // Ensure Default Constructor is deleted
+            // Disabling default, move and copy constructors to match Packet parent
+            UnsubscribePacket() = delete;                                       // Default constructor
+            UnsubscribePacket(const UnsubscribePacket &) = delete;              // Copy constructor
+            UnsubscribePacket(UnsubscribePacket &&) = delete;                   // Move constructor
+            UnsubscribePacket &operator=(const UnsubscribePacket &) & = delete; // Copy assignment operator
+            UnsubscribePacket &operator=(UnsubscribePacket &&) & = delete;      // Move assignment operator
+            virtual ~UnsubscribePacket() = default;                             // Default destructor
 
             /**
              * @brief Constructor
@@ -185,20 +168,14 @@ namespace awsiotsdk {
          */
         class UnsubackPacket : public Packet {
         public:
-            // Ensure Default Constructor is deleted, default to move and copy constructors and assignment operators
-            // Default virtual destructor
-            // Delete Default constructor
-            UnsubackPacket() = delete;
-            // Default Copy constructor
-            UnsubackPacket(const UnsubackPacket &) = default;
-            // Default Move constructor
-            UnsubackPacket(UnsubackPacket &&) = default;
-            // Default Copy assignment operator
-            UnsubackPacket &operator=(const UnsubackPacket &) & = default;
-            // Default Move assignment operator
-            UnsubackPacket &operator=(UnsubackPacket &&) & = default;
-            // Default destructor
-            virtual ~UnsubackPacket() = default;
+            // Ensure Default Constructor is deleted
+            // Disabling default, move and copy constructors to match Packet parent
+            UnsubackPacket() = delete;                                      // Default constructor
+            UnsubackPacket(const UnsubackPacket &) = delete;                // Copy constructor
+            UnsubackPacket(UnsubackPacket &&) = delete;                     // Move constructor
+            UnsubackPacket &operator=(const UnsubackPacket &) & = delete;   // Copy assignment operator
+            UnsubackPacket &operator=(UnsubackPacket &&) & = delete;        // Move assignment operator
+            virtual ~UnsubackPacket() = default;                            // Default destructor
 
             /**
              * @brief Constructor


### PR DESCRIPTION
*Issue #170:*
Build failed on trunk in MacOS

*Description of changes:*
Explicitly deleted  all implicitly deleted copy and move constructors and assignment operators

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
