### PR TITLE
Fixed googletest branch

### DIFF
--- a/tests/unit/CMakeLists-gtest.txt.in
+++ b/tests/unit/CMakeLists-gtest.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/third_party/googletest/src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/third_party/googletest/build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
https://github.com/google/googletest/issues/3663

googletest branch 'master' has dropped and ref was broken.

Just fixed GIT_TAG from master to main.