### PR TITLE
Changed OpenSSL version in documentation from 1.0.2 to 1.1.0

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -46,9 +46,9 @@ The SDK will never create or destroy a Network Instance or perform any other ope
 An additional feature of the SDK is the ability for all actions to do partial Network Read and Writes. The Code for this is located in [src/Action.cpp](./src/Action.cpp).
 
 As mentioned in the [README.md](./README.md) file, The SDK itself provides the below reference implementations for Network Connection:
- * MQTT over TLS using OpenSSL 1.0.2
+ * MQTT over TLS using OpenSSL 1.1.0
  * MQTT over TLS using MbedTLS
- * MQTT over WebSocket using OpenSSL 1.0.2 as the underlying TLS layer
+ * MQTT over WebSocket using OpenSSL 1.1.0 as the underlying TLS layer
 
 Details on how a custom network connection class can be created are available in the Network Connection [README.md](./network/README.md)
 

--- a/Platform.md
+++ b/Platform.md
@@ -25,10 +25,8 @@ This file contains instructions for installing dependencies on different platfor
     
  `sudo update-alternatives --config gcc`
  `sudo update-alternatives --config g++`
-  * Install Openssl 1.0.2. Linux From Scratch has good guides on installing versions of OpenSSL from source. 
-  * Build libssl-dev 1.0.2 or above.
-    * Download libssl-dev_1.0.2 [libssl-dev_1.0.2](http://mirrors.manchester.m247.com/raspbian/pool/main/o/openssl/libssl-dev_1.0.2j-1_armhf.deb)
-    * run `sudo dpkg -i libssl-dev_1.0.2j-1_armhf.deb`
+  * Install Openssl 1.1.0. Linux From Scratch has good guides on installing versions of OpenSSL from source. 
+  * Build libssl-dev 1.1.0 or above.
 
 ### Mac OS
   * Install Homebrew if it's not installed `$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
@@ -40,8 +38,8 @@ This file contains instructions for installing dependencies on different platfor
       * Add the following line to the paths already present `/Applications/CMake.app/Contents/bin`
       * save and quit
       * In a new terminal window, run `echo $PATH`. The path for CMake should be displayed, along with the other paths. 
-  * With Mac OS, the default version of OpenSSL is not 1.0.2 and cannot be used with the SDK. Instead, version 1.0.2 needs to be installed.
-    To install OpenSSL 1.0.2:
+  * With Mac OS, the default version of OpenSSL is not 1.1.0 and cannot be used with the SDK. Instead, version 1.1.0 needs to be installed.
+    To install OpenSSL 1.1.0:
     * Update brew `brew update && brew upgrade`
     * Run `brew info openssl` to list the versions of openssl available
       Example output:
@@ -53,11 +51,11 @@ This file contains instructions for installing dependencies on different platfor
        /usr/local/Cellar/openssl/1.0.2l (1,709 files, 12.1MB)
          Poured from bottle on 2017-05-31 at 15:32:30`
       Use the latest stable 1.0.2 version available, which is 1.0.2l here   
-    * Run `brew switch openssl <latest stable 1.0.2 version>`. If the version is already installed, the path for this version of OpenSSL will be displayed.
+    * Run `brew switch openssl <latest stable 1.1.0 version>`. If the version is already installed, the path for this version of OpenSSL will be displayed.
       Example output:
       `Cleaning /usr/local/Cellar/openssl/1.0.2l
-       Opt link created for /usr/local/Cellar/openssl/1.0.2l`
-      Use the path (`/usr/local/Cellar/openssl/1.0.2l` in the example above) in your <BASE_SDK_DIRECTORY>/network/CMakeLists.txt 
+       Opt link created for /usr/local/Cellar/openssl/1.1.0l`
+      Use the path (`/usr/local/Cellar/openssl/1.1.0l` in the example above) in your <BASE_SDK_DIRECTORY>/network/CMakeLists.txt 
     * If not installed, run `brew install openssl --force`  after the switch operation. The path will be displayed at the end of the installation. 
   
   After that follow the below steps.
@@ -74,8 +72,8 @@ This file contains instructions for installing dependencies on different platfor
     
 ### Windows
 
-  * Both the Websocket and OpenSSL builds work on windows. The latest version of OpenSSL 1.0.2 needs to be installed for them to work properly.
-  * Download and install the latest version of OpenSSL 1.0.2 from [this link](https://slproweb.com/products/Win32OpenSSL.html)
+  * Both the Websocket and OpenSSL builds work on windows. The latest version of OpenSSL 1.1.0 needs to be installed for them to work properly.
+  * Download and install the latest version of OpenSSL 1.1.0 from [this link](https://slproweb.com/products/Win32OpenSSL.html)
   * Download and install CMake for Windows from [this link](https://cmake.org/download/)
   * Download and install git from [this link](https://git-scm.com/downloads). Please be sure to install git bash as well.
   * Open the Git Bash terminal and navigate to the folder where you want the SDK to be downloaded.
@@ -92,12 +90,12 @@ This file contains instructions for installing dependencies on different platfor
 
 ### Ubuntu 14.04
   * Install CMake [CMake Installation](https://cmake.org/install/)
-  * To update to OpenSSL 1.0.2
+  * To update to OpenSSL 1.1.0
     
     * `sudo apt-get install make` (if not already installed)
-    * `wget https://www.openssl.org/source/openssl-1.0.2g.tar.gz` 
-    * `tar -xzvf openssl-1.0.2g.tar.gz` 
-    * `cd openssl-1.0.2g`
+    * `wget https://www.openssl.org/source/openssl-1.1.0g.tar.gz` 
+    * `tar -xzvf openssl-1.1.0g.tar.gz` 
+    * `cd openssl-1.1.0g`
     * `sudo ./config` 
     * `sudo make install`
     * `sudo ln -sf /usr/local/ssl/bin/openssl <which openssl>`

--- a/Platform.md
+++ b/Platform.md
@@ -51,11 +51,11 @@ This file contains instructions for installing dependencies on different platfor
        /usr/local/Cellar/openssl/1.0.2l (1,709 files, 12.1MB)
          Poured from bottle on 2017-05-31 at 15:32:30`
       Use the latest stable 1.0.2 version available, which is 1.0.2l here   
-    * Run `brew switch openssl <latest stable 1.1.0 version>`. If the version is already installed, the path for this version of OpenSSL will be displayed.
+    * Run `brew switch openssl@<latest stable 1.1 version>`. If the version is already installed, the path for this version of OpenSSL will be displayed.
       Example output:
       `Cleaning /usr/local/Cellar/openssl/1.0.2l
-       Opt link created for /usr/local/Cellar/openssl/1.1.0l`
-      Use the path (`/usr/local/Cellar/openssl/1.1.0l` in the example above) in your <BASE_SDK_DIRECTORY>/network/CMakeLists.txt 
+       Opt link created for /usr/local/Cellar/openssl@1.1/1.1.1m`
+      Use the path (`/usr/local/Cellar/openssl@1.1/1.1.1m` in the example above) in your <BASE_SDK_DIRECTORY>/network/CMakeLists.txt 
     * If not installed, run `brew install openssl --force`  after the switch operation. The path will be displayed at the end of the installation. 
   
   After that follow the below steps.
@@ -93,7 +93,7 @@ This file contains instructions for installing dependencies on different platfor
   * To update to OpenSSL 1.1.0
     
     * `sudo apt-get install make` (if not already installed)
-    * `wget https://www.openssl.org/source/openssl-1.1.0g.tar.gz` 
+    * `wget https://www.openssl.org/source/openssl-1.1.0.tar.gz` 
     * `tar -xzvf openssl-1.1.0g.tar.gz` 
     * `cd openssl-1.1.0g`
     * `sudo ./config` 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Prerequisites:
 
  * Make sure to have latest CMake installed. Minimum required version is 3.2
  * Compiler should support C++11 features. We have tested this SDK with gcc 5+, clang 3.8 and on Visual Studio 2015.
- * Openssl has version 1.1.0 and libssl-dev has version 1.0.2. OpenSSL v1.1.0 reference wrapper implementation is not included in this version of the SDK.
+ * OpenSSL has version 1.1.0 and libssl-dev has version 1.1.0. OpenSSL v1.1.0 reference wrapper implementation is not included in this version of the SDK.
  * You can find basic information on how to set up the above on some popular platforms in [Platform.md](https://github.com/aws/aws-iot-device-sdk-cpp/blob/master/Platform.md)
 
 Build Targets:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Prerequisites:
 
  * Make sure to have latest CMake installed. Minimum required version is 3.2
  * Compiler should support C++11 features. We have tested this SDK with gcc 5+, clang 3.8 and on Visual Studio 2015.
- * OpenSSL has version 1.1.0 and libssl-dev has version 1.1.0. OpenSSL v1.1.0 reference wrapper implementation is not included in this version of the SDK.
+ * OpenSSL has version 1.1.0 and libssl-dev has version 1.1.0.
  * You can find basic information on how to set up the above on some popular platforms in [Platform.md](https://github.com/aws/aws-iot-device-sdk-cpp/blob/master/Platform.md)
 
 Build Targets:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Prerequisites:
 
  * Make sure to have latest CMake installed. Minimum required version is 3.2
  * Compiler should support C++11 features. We have tested this SDK with gcc 5+, clang 3.8 and on Visual Studio 2015.
- * Openssl has version 1.0.2 and libssl-dev has version 1.0.2. OpenSSL v1.1.0 reference wrapper implementation is not included in this version of the SDK.
+ * Openssl has version 1.1.0 and libssl-dev has version 1.0.2. OpenSSL v1.1.0 reference wrapper implementation is not included in this version of the SDK.
  * You can find basic information on how to set up the above on some popular platforms in [Platform.md](https://github.com/aws/aws-iot-device-sdk-cpp/blob/master/Platform.md)
 
 Build Targets:
@@ -100,13 +100,13 @@ The platform should be able to provide a C++11 compatible threading implementati
 TLS libraries can be added by simply implementing a derived class of NetworkConnection and providing an instance to the Client.
 We provide the following reference implementations for the Network layer:
 
- * OpenSSL - MQTT over TLS using OpenSSL v1.0.2. Tested on Windows (VS 2015) and Linux
+ * OpenSSL - MQTT over TLS using OpenSSL v1.1.0. Tested on Windows (VS 2015) and Linux
  	* The provided implementation requires OpenSSL to be pre-installed on the device
  	* Use the mqtt port setting from the config file while setting up the network instance
  * MbedTLS - MQTT over TLS using MbedTLS. Tested on Linux
  	* The provided implementation will download MbedTLS v2.3.0 from the github repo and build and link to the libraries. Please be warned that the default configuration of MbedTLS limits packet sizes to 16K
  	* Use the mqtt port setting from the config file while setting up the network instance
- * WebSocket - MQTT over WebSocket. Tested on both Windows (VS 2015) and Linux. Uses OpenSSL 1.0.2 as the underlying TLS layer
+ * WebSocket - MQTT over WebSocket. Tested on both Windows (VS 2015) and Linux. Uses OpenSSL 1.1.0 as the underlying TLS layer
  	* The provided implementation requires OpenSSL to be pre-installed on the device
  	* Please be aware that while the provided reference implementation allows initialization of credentials from any source, the recommended way to do so is to use the aws cli to generate credential files and read the generated files
  	* Use the https port setting from the config file while setting up the network instance

--- a/network/CMakeLists.txt.in
+++ b/network/CMakeLists.txt.in
@@ -70,7 +70,7 @@ else()
 			set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
 		endif()
 		find_package(OpenSSL REQUIRED)
-		#if using Mac OS, you can comment find_package(OpenSSL REQUIRED) and uncomment following two lines. Change the path to your openssl 1.0.2 directory.
+		#if using Mac OS, you can comment find_package(OpenSSL REQUIRED) and uncomment following two lines. Change the path to your openssl 1.1.0 directory.
 		#set(OPENSSL_INCLUDE_DIR "YOUR_OPENSSL_PATH/include")
 		#set(OPENSSL_LIBRARIES "YOUR_OPENSSL_PATH/lib/libssl.a;YOUR_OPENSSL_PATH/lib/libcrypto.a")
 	endif()


### PR DESCRIPTION
*Description of changes:*

Changes references to OpenSSL version 1.0.2 to OpenSSL version 1.1.0, which is known to work with this repository.

This PR removes the reference to the OpenSSL install location for Raspberry PI, as the mirror previously used does not have a cached version 1.1.0+ version of SSL.

~*Currently in draft as I do a reference check and build test*~ Tested with the Pub-Sub sample and it works fully as expected.
(*Note: Requires the changes in #194 for compiling and testing*)

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
