### PR TITLE
Give explicit permissions to Github actions.

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -5,13 +5,15 @@ on:
 jobs:
     auto_comment:
         runs-on: ubuntu-latest
+        permissions:
+          issues: write
         steps:
         - uses: aws-actions/closed-issue-message@v1
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"
             message: |
-                     ### ⚠️COMMENT VISIBILITY WARNING⚠️ 
-                     Comments on closed issues are hard for our team to see. 
-                     If you need more assistance, please either tag a team member or open a new issue that references this one. 
+                     ### ⚠️COMMENT VISIBILITY WARNING⚠️
+                     Comments on closed issues are hard for our team to see.
+                     If you need more assistance, please either tag a team member or open a new issue that references this one.
                      If you wish to keep having a conversation with other community members under this issue feel free to do so.

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -9,6 +9,9 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@v3
       with:


### PR DESCRIPTION
Actions no longer have write permission by default


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
